### PR TITLE
[FIXED JENKINS-29255] Restricting secret file visibility to avoid "WARNING: UNPROTECTED PRIVATE KEY FILE!" when using as ssh key

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/credentialsbinding/impl/FileBinding.java
+++ b/src/main/java/org/jenkinsci/plugins/credentialsbinding/impl/FileBinding.java
@@ -58,6 +58,7 @@ public class FileBinding extends Binding<FileCredentials> {
         secrets.chmod(/*0700*/448);
         FilePath secret = dir.child(credentials.getFileName());
         copy(secret, credentials);
+        secret.chmod(0400);
         return new SingleEnvironment(secret.getRemote(), new UnbinderImpl(dirName));
     }
     


### PR DESCRIPTION
[JENKINS-29255](https://issues.jenkins-ci.org/browse/JENKINS-29255)