### PR TITLE
[JENKINS-27631] Stronger tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
   </description>
   <url>http://wiki.jenkins-ci.org/display/JENKINS/Credentials+Binding+Plugin</url>
   <properties>
-    <workflow.version>1.1</workflow.version>
+    <workflow.version>1.4</workflow.version>
   </properties>
   <licenses>
     <license>

--- a/src/test/java/org/jenkinsci/plugins/credentialsbinding/impl/BindingStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/credentialsbinding/impl/BindingStepTest.java
@@ -89,11 +89,11 @@ public class BindingStepTest {
                 p.setDefinition(new CpsFlowDefinition(""
                         + "node {\n"
                         + "  withCredentials([[$class: 'UsernamePasswordMultiBinding', usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD', credentialsId: '" + credentialsId + "']]) {\n"
+                        + "    semaphore 'basics'\n"
                         + "    sh '''\n"
                         + "      set +x\n"
                         + "      echo curl -u $USERNAME:$PASSWORD server > script.sh\n"
                         + "    '''\n"
-                        + "    semaphore 'basics'\n"
                         + "  }\n"
                         + "}", true));
                 WorkflowRun b = p.scheduleBuild2(0).waitForStart();

--- a/src/test/java/org/jenkinsci/plugins/credentialsbinding/impl/BindingStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/credentialsbinding/impl/BindingStepTest.java
@@ -36,28 +36,29 @@ import hudson.model.Result;
 import hudson.slaves.DumbSlave;
 import hudson.slaves.NodeProperty;
 import hudson.slaves.RetentionStrategy;
-import java.io.File;
-import java.util.Collections;
-
 import hudson.util.Secret;
+import java.io.File;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Set;
+import java.util.TreeSet;
+import javax.inject.Inject;
 import org.apache.commons.io.FileUtils;
 import org.jenkinsci.plugins.credentialsbinding.MultiBinding;
 import org.jenkinsci.plugins.plaincredentials.impl.FileCredentialsImpl;
 import org.jenkinsci.plugins.plaincredentials.impl.StringCredentialsImpl;
-import org.jenkinsci.plugins.plaincredentials.impl.StringCredentialsImpl.DescriptorImpl;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.jenkinsci.plugins.workflow.steps.StepConfigTester;
 import org.jenkinsci.plugins.workflow.test.steps.SemaphoreStep;
-import org.junit.Test;
 import static org.junit.Assert.*;
 import org.junit.Rule;
+import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.junit.runners.model.Statement;
+import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.RestartableJenkinsRule;
-
-import javax.inject.Inject;
 
 public class BindingStepTest {
 
@@ -79,22 +80,27 @@ public class BindingStepTest {
     @Test public void basics() throws Exception {
         story.addStep(new Statement() {
             @Override public void evaluate() throws Throwable {
-                UsernamePasswordCredentialsImpl c = new UsernamePasswordCredentialsImpl(CredentialsScope.GLOBAL, "creds", "sample", "bob", "s3cr3t");
+                String credentialsId = "creds";
+                String username = "bob";
+                String password = "s3cr3t";
+                UsernamePasswordCredentialsImpl c = new UsernamePasswordCredentialsImpl(CredentialsScope.GLOBAL, credentialsId, "sample", username, password);
                 CredentialsProvider.lookupStores(story.j.jenkins).iterator().next().addCredentials(Domain.global(), c);
                 WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, "p");
                 p.setDefinition(new CpsFlowDefinition(""
                         + "node {\n"
-                        + "  withCredentials([[$class: 'UsernamePasswordMultiBinding', usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD', credentialsId: 'creds']]) {\n"
+                        + "  withCredentials([[$class: 'UsernamePasswordMultiBinding', usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD', credentialsId: '" + credentialsId + "']]) {\n"
                         + "    sh '''\n"
                         + "      set +x\n"
                         + "      echo curl -u $USERNAME:$PASSWORD server > script.sh\n"
                         + "    '''\n"
                         + "  }\n"
                         + "}", true));
-                story.j.assertLogNotContains("s3cr3t", story.j.assertBuildStatusSuccess(p.scheduleBuild2(0)));
+                WorkflowRun b = story.j.assertBuildStatusSuccess(p.scheduleBuild2(0));
+                story.j.assertLogNotContains(password, b);
                 FilePath script = story.j.jenkins.getWorkspaceFor(p).child("script.sh");
                 assertTrue(script.exists());
-                assertEquals("curl -u bob:s3cr3t server", script.readToString().trim());
+                assertEquals("curl -u " + username + ":" + password + " server", script.readToString().trim());
+                assertEquals(Collections.<String>emptySet(), grep(b.getRootDir(), password));
             }
         });
     }
@@ -120,16 +126,17 @@ public class BindingStepTest {
                 story.j.assertLogContains(CredentialNotFoundException.class.getName(), r);
                 story.j.assertLogContains(StandardUsernamePasswordCredentials.class.getName(), r);
                 story.j.assertLogContains(stringCredentialsDescriptor.getDisplayName(), r);
-                System.out.println(r.getLog());
+                System.out.println(JenkinsRule.getLog(r)); // TODO 1.607+ use BuildWatcher
             }
         });
     }
 
     @Test public void cleanupAfterRestart() throws Exception {
+        final String secret = "s3cr3t";
         story.addStep(new Statement() {
             @Override public void evaluate() throws Throwable {
                 File originalSecret = tmp.newFile();
-                FileUtils.write(originalSecret, "s3cr3t");
+                FileUtils.write(originalSecret, secret);
                 FileCredentialsImpl c = new FileCredentialsImpl(CredentialsScope.GLOBAL, "creds", "sample", new FileParameterValue.FileItemImpl(originalSecret), null, null);
                 CredentialsProvider.lookupStores(story.j.jenkins).iterator().next().addCredentials(Domain.global(), c);
                 // TODO JENKINS-26398: story.j.createSlave("myslave", null, null) does not work since the slave root is deleted after restart.
@@ -153,19 +160,40 @@ public class BindingStepTest {
                 assertNotNull(p);
                 WorkflowRun b = p.getBuildByNumber(1);
                 assertNotNull(b);
-                while (b.isBuilding()) { // TODO JENKINS-26399 need utility in JenkinsRule
+                while (b.isBuilding()) { // TODO 1.607+ use waitForCompletion
                     Thread.sleep(100);
                 }
                 story.j.assertBuildStatusSuccess(b);
-                story.j.assertLogNotContains("s3cr3t", b);
+                story.j.assertLogNotContains(secret, b);
                 FilePath key = story.j.jenkins.getNode("myslave").getWorkspaceFor(p).child("key");
                 assertTrue(key.exists());
-                assertEquals("s3cr3t", key.readToString());
+                assertEquals(secret, key.readToString());
                 FilePath secretFiles = story.j.jenkins.getNode("myslave").getRootPath().child("secretFiles");
                 assertTrue(secretFiles.isDirectory());
                 assertEquals(Collections.emptyList(), secretFiles.list());
+                assertEquals(Collections.<String>emptySet(), grep(b.getRootDir(), secret));
             }
         });
+    }
+
+    private static Set<String> grep(File dir, String text) throws IOException {
+        Set<String> matches = new TreeSet<String>();
+        grep(dir, text, "", matches);
+        return matches;
+    }
+    private static void grep(File dir, String text, String prefix, Set<String> matches) throws IOException {
+        File[] kids = dir.listFiles();
+        if (kids == null) {
+            return;
+        }
+        for (File kid : kids) {
+            String qualifiedName = prefix + kid.getName();
+            if (kid.isDirectory()) {
+                grep(kid, text, qualifiedName + "/", matches);
+            } else if (kid.isFile() && FileUtils.readFileToString(kid).contains(text)) {
+                matches.add(qualifiedName);
+            }
+        }
     }
 
 }

--- a/src/test/java/org/jenkinsci/plugins/credentialsbinding/impl/BindingStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/credentialsbinding/impl/BindingStepTest.java
@@ -171,11 +171,12 @@ public class BindingStepTest {
         });
         story.addStep(new Statement() {
             @Override public void evaluate() throws Throwable {
-                SemaphoreStep.success("cleanupAfterRestart/1", null);
                 WorkflowJob p = story.j.jenkins.getItemByFullName("p", WorkflowJob.class);
                 assertNotNull(p);
                 WorkflowRun b = p.getBuildByNumber(1);
                 assertNotNull(b);
+                assertEquals(Collections.<String>emptySet(), grep(b.getRootDir(), secret));
+                SemaphoreStep.success("cleanupAfterRestart/1", null);
                 while (b.isBuilding()) { // TODO 1.607+ use waitForCompletion
                     Thread.sleep(100);
                 }

--- a/src/test/java/org/jenkinsci/plugins/credentialsbinding/impl/BindingStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/credentialsbinding/impl/BindingStepTest.java
@@ -102,11 +102,12 @@ public class BindingStepTest {
         });
         story.addStep(new Statement() {
             @Override public void evaluate() throws Throwable {
-                SemaphoreStep.success("basics/1", null);
                 WorkflowJob p = story.j.jenkins.getItemByFullName("p", WorkflowJob.class);
                 assertNotNull(p);
                 WorkflowRun b = p.getBuildByNumber(1);
                 assertNotNull(b);
+                assertEquals("TODO JENKINS-27631", Collections.singleton("program.dat"), grep(b.getRootDir(), password));
+                SemaphoreStep.success("basics/1", null);
                 while (b.isBuilding()) { // TODO 1.607+ use waitForCompletion
                     Thread.sleep(100);
                 }


### PR DESCRIPTION
[JENKINS-27631](https://issues.jenkins-ci.org/browse/JENKINS-27631)

I lay awake in bed wondering whether the contextual `EnvVars` got stored somewhere unsafe. Turns out it does, though only temporarily. This PR just makes the test coverage more interesting.

@reviewbybees