### PR TITLE
[JENKINS-24805] Mask all bindings with asterix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
   <groupId>org.jenkins-ci.plugins</groupId>
   <artifactId>credentials-binding</artifactId>
-  <version>1.6</version>
+  <version>1.7-SNAPSHOT</version>
   <packaging>hpi</packaging>
 
   <name>Credentials Binding Plugin</name>
@@ -31,7 +31,7 @@
     <connection>scm:git:git://github.com/jenkinsci/${project.artifactId}-plugin.git</connection>
     <developerConnection>scm:git:git@github.com:jenkinsci/${project.artifactId}-plugin.git</developerConnection>
     <url>https://github.com/jenkinsci/${project.artifactId}-plugin</url>
-    <tag>credentials-binding-1.6</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <repositories>

--- a/src/main/java/org/jenkinsci/plugins/credentialsbinding/impl/BindingStep.java
+++ b/src/main/java/org/jenkinsci/plugins/credentialsbinding/impl/BindingStep.java
@@ -125,7 +125,7 @@ public final class BindingStep extends AbstractStepImpl {
     }
 
     /** Similar to {@code MaskPasswordsOutputStream}. */
-    private static final class Filter extends ConsoleLogFilter implements Serializable {
+    static final class Filter extends ConsoleLogFilter implements Serializable {
 
         private static final long serialVersionUID = 1;
 

--- a/src/main/java/org/jenkinsci/plugins/credentialsbinding/impl/BindingStep.java
+++ b/src/main/java/org/jenkinsci/plugins/credentialsbinding/impl/BindingStep.java
@@ -40,6 +40,8 @@ import java.io.OutputStream;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -130,10 +132,19 @@ public final class BindingStep extends AbstractStepImpl {
         private static final long serialVersionUID = 1;
 
         private final Secret pattern;
+        
+        private static final Comparator<String> StringLengthComparator = new Comparator<String>() {
+			@Override
+			public int compare(String o1, String o2) {
+				return o1.length() - o2.length();
+			}
+		};
 
         Filter(Collection<String> secrets) {
             StringBuilder b = new StringBuilder();
-            for (String secret : secrets) {
+            List<String> hiddenSecrets = new ArrayList<String>(secrets);
+            hiddenSecrets.sort(StringLengthComparator.reversed());
+            for (String secret : hiddenSecrets) {
                 if (b.length() > 0) {
                     b.append('|');
                 }

--- a/src/main/java/org/jenkinsci/plugins/credentialsbinding/impl/BindingStep.java
+++ b/src/main/java/org/jenkinsci/plugins/credentialsbinding/impl/BindingStep.java
@@ -143,7 +143,8 @@ public final class BindingStep extends AbstractStepImpl {
         Filter(Collection<String> secrets) {
             StringBuilder b = new StringBuilder();
             List<String> hiddenSecrets = new ArrayList<String>(secrets);
-            hiddenSecrets.sort(StringLengthComparator.reversed());
+            Collections.sort(hiddenSecrets, StringLengthComparator);
+            Collections.reverse(hiddenSecrets);
             for (String secret : hiddenSecrets) {
                 if (b.length() > 0) {
                     b.append('|');

--- a/src/main/java/org/jenkinsci/plugins/credentialsbinding/impl/FileBinding.java
+++ b/src/main/java/org/jenkinsci/plugins/credentialsbinding/impl/FileBinding.java
@@ -50,7 +50,9 @@ public class FileBinding extends Binding<FileCredentials> {
     }
 
     @Override public SingleEnvironment bindSingle(Run<?,?> build, FilePath workspace, Launcher launcher, TaskListener listener) throws IOException, InterruptedException {
-        FileCredentials credentials = getCredentials(build);
+        if(workspace==null)
+        	return new SingleEnvironment("");
+    	FileCredentials credentials = getCredentials(build);
         FilePath secrets = secretsDir(workspace);
         String dirName = UUID.randomUUID().toString();
         final FilePath dir = secrets.child(dirName);

--- a/src/main/java/org/jenkinsci/plugins/credentialsbinding/impl/SecretBuildWrapper.java
+++ b/src/main/java/org/jenkinsci/plugins/credentialsbinding/impl/SecretBuildWrapper.java
@@ -95,10 +95,8 @@ public class SecretBuildWrapper extends BuildWrapper {
     		return super.decorateLogger(build, logger);
     	
     	Map<String,String> overrides = new HashMap<String,String>();
-        List<MultiBinding.Unbinder> unbinders = new ArrayList<MultiBinding.Unbinder>();
         for (MultiBinding<?> binding : bindings) {
-            MultiBinding.MultiEnvironment environment = binding.bind(build, build.getWorkspace(), null, null);
-            unbinders.add(environment.getUnbinder());
+            MultiBinding.MultiEnvironment environment = binding.bind(build, null, null, null);
             overrides.putAll(environment.getValues());
         }
         return new BindingStep.Filter(overrides.values()).decorateLogger(build, logger);

--- a/src/main/java/org/jenkinsci/plugins/credentialsbinding/impl/SecretBuildWrapper.java
+++ b/src/main/java/org/jenkinsci/plugins/credentialsbinding/impl/SecretBuildWrapper.java
@@ -41,6 +41,7 @@ import java.util.Map;
 import java.util.Set;
 import org.jenkinsci.plugins.credentialsbinding.MultiBinding;
 import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.DataBoundSetter;
 
 @SuppressWarnings({"rawtypes", "unchecked"}) // inherited from BuildWrapper
 public class SecretBuildWrapper extends BuildWrapper {
@@ -48,13 +49,23 @@ public class SecretBuildWrapper extends BuildWrapper {
     private final List<? extends MultiBinding<?>> bindings;
     private boolean showBindings;
 
-    @DataBoundConstructor public SecretBuildWrapper(List<? extends MultiBinding<?>> bindings, boolean showBindings) {
+    public SecretBuildWrapper(List<? extends MultiBinding<?>> bindings, boolean showBindings) {
         this.bindings = bindings;
         this.showBindings = showBindings;
     }
     
+    @DataBoundConstructor public SecretBuildWrapper(List<? extends MultiBinding<?>> bindings) {
+        this.bindings = bindings;
+        showBindings = true;
+    }
+    
     public List<? extends MultiBinding<?>> getBindings() {
         return bindings;
+    }
+    
+    @DataBoundSetter
+    public void setShowBindings(boolean showBindings) {
+        this.showBindings = showBindings;
     }
 
     @Override public Environment setUp(AbstractBuild build, final Launcher launcher, BuildListener listener) throws IOException, InterruptedException {

--- a/src/main/resources/org/jenkinsci/plugins/credentialsbinding/impl/SecretBuildWrapper/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/credentialsbinding/impl/SecretBuildWrapper/config.jelly
@@ -29,4 +29,9 @@ THE SOFTWARE.
             <f:repeatableHeteroProperty field="bindings" hasHeader="true"/>
         </f:block>
     </f:section>
+    <f:advanced>
+    	<f:entry title="Show bindings" field="showBindings" description="If checked, all secret variable bindings will be clear-text.">
+			<f:checkbox />
+		</f:entry>
+    </f:advanced>
 </j:jelly>

--- a/src/test/java/org/jenkinsci/plugins/credentialsbinding/impl/BindingStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/credentialsbinding/impl/BindingStepTest.java
@@ -257,6 +257,31 @@ public class BindingStepTest {
             }
         });
     }
+    
+    @Issue("JENKINS-24805")
+    @Test public void maskingSimilarSecrets() {
+        story.addStep(new Statement() {
+            @Override public void evaluate() throws Throwable {
+                String credentialsId = "creds";
+                String username = "s3cr3t";
+                String password = username + "EvenLonger";
+                UsernamePasswordCredentialsImpl c = new UsernamePasswordCredentialsImpl(CredentialsScope.GLOBAL, credentialsId, "sample", username, password);
+                CredentialsProvider.lookupStores(story.j.jenkins).iterator().next().addCredentials(Domain.global(), c);
+                WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, "p");
+                p.setDefinition(new CpsFlowDefinition(""
+                        + "node {\n"
+                        + "  withCredentials([[$class: 'UsernamePasswordMultiBinding', usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD', credentialsId: '" + credentialsId + "']]) {\n"
+                        // forgot set +x, ran /usr/bin/env, etc.
+                        + "    sh 'echo $USERNAME:$PASSWORD > oopsEvenLonger'\n"
+                        + "  }\n"
+                        + "}", true));
+                WorkflowRun b = story.j.assertBuildStatusSuccess(p.scheduleBuild2(0).get());
+                story.j.assertLogNotContains(username, b);
+                story.j.assertLogNotContains(password, b);
+                story.j.assertLogContains("echo ****:****", b);
+            }
+        });
+    }
 
     @Issue("JENKINS-30326")
     @Test

--- a/src/test/java/org/jenkinsci/plugins/credentialsbinding/impl/UsernamePasswordBindingTest.java
+++ b/src/test/java/org/jenkinsci/plugins/credentialsbinding/impl/UsernamePasswordBindingTest.java
@@ -29,9 +29,11 @@ import com.cloudbees.plugins.credentials.CredentialsScope;
 import com.cloudbees.plugins.credentials.domains.Domain;
 import com.cloudbees.plugins.credentials.impl.UsernamePasswordCredentialsImpl;
 
+import hudson.Functions;
 import hudson.model.FreeStyleBuild;
 import hudson.model.Item;
 import hudson.model.FreeStyleProject;
+import hudson.tasks.BatchFile;
 import hudson.tasks.Shell;
 
 import java.util.Collections;
@@ -56,8 +58,8 @@ public class UsernamePasswordBindingTest {
         UsernamePasswordCredentialsImpl c = new UsernamePasswordCredentialsImpl(CredentialsScope.GLOBAL, null, "sample", username, password);
         CredentialsProvider.lookupStores(r.jenkins).iterator().next().addCredentials(Domain.global(), c);
         FreeStyleProject p = r.createFreeStyleProject();
-        p.getBuildWrappersList().add(new SecretBuildWrapper(Collections.<Binding<?>>singletonList(new UsernamePasswordBinding("AUTH", c.getId()))));
-        p.getBuildersList().add(new Shell("set +x\necho $AUTH > auth.txt"));
+        p.getBuildWrappersList().add(new SecretBuildWrapper(Collections.<Binding<?>>singletonList(new UsernamePasswordBinding("AUTH", c.getId())), false));
+        p.getBuildersList().add(Functions.isWindows() ? new BatchFile("echo %AUTH% > auth.txt") : new Shell("echo $AUTH > auth.txt"));
         r.configRoundtrip((Item)p);
         SecretBuildWrapper wrapper = p.getBuildWrappersList().get(SecretBuildWrapper.class);
         assertNotNull(wrapper);

--- a/src/test/java/org/jenkinsci/plugins/credentialsbinding/impl/UsernamePasswordMultiBindingTest.java
+++ b/src/test/java/org/jenkinsci/plugins/credentialsbinding/impl/UsernamePasswordMultiBindingTest.java
@@ -58,11 +58,11 @@ public class UsernamePasswordMultiBindingTest {
         UsernamePasswordCredentialsImpl c = new UsernamePasswordCredentialsImpl(CredentialsScope.GLOBAL, null, "sample", username, password);
         CredentialsProvider.lookupStores(r.jenkins).iterator().next().addCredentials(Domain.global(), c);
         FreeStyleProject p = r.createFreeStyleProject();
-        p.getBuildWrappersList().add(new SecretBuildWrapper(Collections.<MultiBinding<?>>singletonList(new UsernamePasswordMultiBinding("userid", "pass", c.getId()))));
+        p.getBuildWrappersList().add(new SecretBuildWrapper(Collections.<MultiBinding<?>>singletonList(new UsernamePasswordMultiBinding("userid", "pass", c.getId())), false));
         if (Functions.isWindows()) {
-            p.getBuildersList().add(new BatchFile("@echo off\necho %userid%/%pass% > auth.txt"));
+            p.getBuildersList().add(new BatchFile("echo %userid%/%pass% > auth.txt"));
         } else {
-            p.getBuildersList().add(new Shell("set +x\necho $userid/$pass > auth.txt"));
+            p.getBuildersList().add(new Shell("echo $userid/$pass > auth.txt"));
         }
         r.configRoundtrip((Item)p);
         SecretBuildWrapper wrapper = p.getBuildWrappersList().get(SecretBuildWrapper.class);


### PR DESCRIPTION
- Order bindings by largest to shortest string to cover substrings
- Fix an issue if secret is partially duplicated, e.g. "android"
  "androiddebugkey" which results in "***_" and "**_*debugkey"
