### PR TITLE
Mention secret text as part of pipeline option.

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/credentialsbinding/impl/BindingStep/help.html
+++ b/src/main/resources/org/jenkinsci/plugins/credentialsbinding/impl/BindingStep/help.html
@@ -49,10 +49,21 @@ node {
 <p>
     to ensure that the secrets are outside the workspace; or choose a different workspace entirely:
 </p>
+<pre><code>
 node {
   ws {
     withCredentials([[$class: 'FileBinding', credentialsId: 'secret', variable: 'FILE']]) {
       sh 'use $FILE'
     }
+  }
+}</code></pre>
+
+<p>
+    You can also access secret text credentials:
+</p>    
+<pre><code>
+node {
+  withCredentials([[$class: 'StringBinding', credentialsId: 'mytoken', variable: 'TOKEN' ]]) {
+    sh 'use $TOKEN'
   }
 }</code></pre>


### PR DESCRIPTION
You can use the secret text credentials with the pipeline step.  This should be added to the documentation.  I'm copied this from [#347](https://github.com/jenkins-infra/jenkins.io/pull/347) since that file is generated from the help.html from this plugin.

cc @nzakas to ensure the info is still accurate