### PR TITLE
Ease writing of new on-disk Binding implementations

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/credentialsbinding/impl/AbstractOnDiskBinding.java
+++ b/src/main/java/org/jenkinsci/plugins/credentialsbinding/impl/AbstractOnDiskBinding.java
@@ -47,11 +47,11 @@ public abstract class AbstractOnDiskBinding<C extends StandardCredentials> exten
      */
     abstract protected FilePath write(C credentials, FilePath dir) throws IOException, InterruptedException;
 
-    private static class UnbinderImpl implements Unbinder {
+    protected static class UnbinderImpl implements Unbinder {
         private static final long serialVersionUID = 1;
         private final String dirName;
 
-        private UnbinderImpl(String dirName) {
+        protected UnbinderImpl(String dirName) {
             this.dirName = dirName;
         }
 

--- a/src/main/java/org/jenkinsci/plugins/credentialsbinding/impl/AbstractOnDiskBinding.java
+++ b/src/main/java/org/jenkinsci/plugins/credentialsbinding/impl/AbstractOnDiskBinding.java
@@ -1,0 +1,73 @@
+package org.jenkinsci.plugins.credentialsbinding.impl;
+
+import java.io.IOException;
+import java.util.UUID;
+
+import org.jenkinsci.plugins.credentialsbinding.Binding;
+
+import com.cloudbees.plugins.credentials.common.StandardCredentials;
+
+import hudson.FilePath;
+import hudson.Launcher;
+import hudson.model.TaskListener;
+import hudson.model.Run;
+import hudson.slaves.WorkspaceList;
+
+/**
+ * Base class for writing credentials to a file or directory, and binding its path to a single variable. Handles
+ * creation of a -rwx------ temporary directory, and its full deletion when unbinding.
+ * @param <C> a kind of credentials
+ */
+public abstract class AbstractOnDiskBinding<C extends StandardCredentials> extends Binding<C> {
+
+    protected AbstractOnDiskBinding(String variable, String credentialsId) {
+        super(variable, credentialsId);
+    }
+
+    @Override
+    public final SingleEnvironment bindSingle(Run<?, ?> build, FilePath workspace, Launcher launcher, TaskListener listener) throws IOException, InterruptedException {
+        final FilePath secrets = secretsDir(workspace);
+        final String dirName = UUID.randomUUID().toString();
+        final FilePath dir = secrets.child(dirName);
+        dir.mkdirs();
+        secrets.chmod(0700);
+        dir.chmod(0700);
+        final FilePath secret = write(getCredentials(build), dir);
+        return new SingleEnvironment(secret.getRemote(), new UnbinderImpl(dirName));
+    }
+
+    /**
+     * Writes credentials under a given temporary directory, and returns their path (will be bound to the variable).
+     * @param credentials the credentials to bind
+     * @param dir a temporary directory where credentials should be written. You can assume it has already been created,
+     *            with secure permissions.
+     * @return the path to the on-disk credentials, to be bound to the variable
+     * @throws IOException
+     * @throws InterruptedException
+     */
+    abstract protected FilePath write(C credentials, FilePath dir) throws IOException, InterruptedException;
+
+    private static class UnbinderImpl implements Unbinder {
+        private static final long serialVersionUID = 1;
+        private final String dirName;
+
+        private UnbinderImpl(String dirName) {
+            this.dirName = dirName;
+        }
+
+        @Override
+        public void unbind(Run<?, ?> build, FilePath workspace, Launcher launcher, TaskListener listener) throws IOException, InterruptedException {
+            secretsDir(workspace).child(dirName).deleteRecursive();
+        }
+    }
+
+    private static FilePath secretsDir(FilePath workspace) {
+        return tempDir(workspace).child("secretFiles");
+    }
+
+    // TODO 1.652 use WorkspaceList.tempDir
+    private static FilePath tempDir(FilePath ws) {
+        return ws.sibling(ws.getName() + System.getProperty(WorkspaceList.class.getName(), "@") + "tmp");
+    }
+
+}

--- a/src/main/java/org/jenkinsci/plugins/credentialsbinding/impl/AbstractOnDiskBinding.java
+++ b/src/main/java/org/jenkinsci/plugins/credentialsbinding/impl/AbstractOnDiskBinding.java
@@ -4,6 +4,8 @@ import java.io.IOException;
 import java.util.UUID;
 
 import org.jenkinsci.plugins.credentialsbinding.Binding;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 
 import com.cloudbees.plugins.credentials.common.StandardCredentials;
 
@@ -47,6 +49,7 @@ public abstract class AbstractOnDiskBinding<C extends StandardCredentials> exten
      */
     abstract protected FilePath write(C credentials, FilePath dir) throws IOException, InterruptedException;
 
+    @Restricted(NoExternalUse.class)
     protected static class UnbinderImpl implements Unbinder {
         private static final long serialVersionUID = 1;
         private final String dirName;

--- a/src/main/java/org/jenkinsci/plugins/credentialsbinding/impl/FileBinding.java
+++ b/src/main/java/org/jenkinsci/plugins/credentialsbinding/impl/FileBinding.java
@@ -45,20 +45,9 @@ public class FileBinding extends AbstractOnDiskBinding<FileCredentials> {
 
     @Override protected final FilePath write(FileCredentials credentials, FilePath dir) throws IOException, InterruptedException {
         FilePath secret = dir.child(credentials.getFileName());
-        copy(secret, credentials);
-        if (secret.isDirectory()) { /* ZipFileBinding */
-            // needs to be writable so we can delete its contents
-            // needs to be executable so we can list the contents
-            secret.chmod(0700);
-        }
-        else {
-            secret.chmod(0400);
-        }
-        return secret;
-    }
-
-    protected void copy(FilePath secret, FileCredentials credentials) throws IOException, InterruptedException {
         secret.copyFrom(credentials.getContent());
+        secret.chmod(0400);
+        return secret;
     }
 
     @Extension public static class DescriptorImpl extends BindingDescriptor<FileCredentials> {

--- a/src/main/java/org/jenkinsci/plugins/credentialsbinding/impl/FileBinding.java
+++ b/src/main/java/org/jenkinsci/plugins/credentialsbinding/impl/FileBinding.java
@@ -59,25 +59,19 @@ public class FileBinding extends AbstractOnDiskBinding<FileCredentials> {
     private static class UnbinderImpl implements Unbinder {
         private static final long serialVersionUID = 1;
         private final String dirName;
-        private transient AbstractOnDiskBinding.UnbinderImpl delegate;
 
         private UnbinderImpl(String dirName) {
             this.dirName = dirName;
         }
 
         protected Object readResolve() {
-            if (dirName != null && delegate == null) {
-                delegate = new AbstractOnDiskBinding.UnbinderImpl(dirName);
-            }
-            return this;
+            return new AbstractOnDiskBinding.UnbinderImpl(dirName);
         }
 
         @Override
         public void unbind(Run<?, ?> build, FilePath workspace, Launcher launcher, TaskListener listener)
                 throws IOException, InterruptedException {
-            if (delegate != null) {
-                delegate.unbind(build, workspace, launcher, listener);
-            }
+            // replaced by the AbstractOnDiskBinding.UnbinderImpl implementation
         }
     }
 

--- a/src/main/java/org/jenkinsci/plugins/credentialsbinding/impl/ZipFileBinding.java
+++ b/src/main/java/org/jenkinsci/plugins/credentialsbinding/impl/ZipFileBinding.java
@@ -43,14 +43,21 @@ import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 
-public class ZipFileBinding extends FileBinding {
+public class ZipFileBinding extends AbstractOnDiskBinding<FileCredentials> {
 
     @DataBoundConstructor public ZipFileBinding(String variable, String credentialsId) {
         super(variable, credentialsId);
     }
 
-    @Override protected void copy(FilePath secret, FileCredentials credentials) throws IOException, InterruptedException {
+    @Override protected Class<FileCredentials> type() {
+        return FileCredentials.class;
+    }
+
+    @Override protected final FilePath write(FileCredentials credentials, FilePath dir) throws IOException, InterruptedException {
+        FilePath secret = dir.child(credentials.getFileName());
         secret.unzipFrom(credentials.getContent());
+        secret.chmod(0700); // note: it's a directory
+        return secret;
     }
 
     @Extension public static class DescriptorImpl extends BindingDescriptor<FileCredentials> {


### PR DESCRIPTION
Following jglick's suggestion in #22, I will make a PR for a Docker client certificate Binding implementation to the docker-commons-plugin. To write it without copy/pasting too much code from FileBinding, I would like to introduce an abstract class for this kind of on-disk credentials binding implementation, which would take care of the temporary directory, but would not be specific to FileCredentials.

**EDIT:** posted the PR for docker-commons: jenkinsci/docker-commons-plugin#54
