### PR TITLE
use jenkins 1.642.4, to avoid requests to usage.jenkins.io from automated tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
   </description>
   <url>http://wiki.jenkins-ci.org/display/JENKINS/Credentials+Binding+Plugin</url>
   <properties>
-    <jenkins.version>1.642.3</jenkins.version>
+    <jenkins.version>1.642.4</jenkins.version>
   </properties>  
   <licenses>
     <license>


### PR DESCRIPTION
https://wiki.jenkins-ci.org/display/JENKINS/Usage+Statistics+Privacy+Advisory+2016-03-30:
It seems to also affect tests execution when jenkins.version=1.642.3, and becomes
annoying when stuck behind a corporate HTTP proxy, because each test execution then
hangs until the TCP connection attempt aborts. Bumping to 1.642.4 is enough to make
the tests fast again.

Here is an example stack captured when the external ressource HTTP request happens
during a test execution (with 1.642.3):

```
"Executing emptySecretsList(org.jenkinsci.plugins.credentialsbinding.impl.SecretBuildWrapperTest)" prio=10 tid=0x00007f855800a800 nid=0x7f69 runnable [0x00007f85622fa000]
   java.lang.Thread.State: RUNNABLE
	at java.net.PlainSocketImpl.socketConnect(Native Method)
	at java.net.AbstractPlainSocketImpl.doConnect(AbstractPlainSocketImpl.java:339)
	- locked <0x00000007e19cbea0> (a java.net.SocksSocketImpl)
	at java.net.AbstractPlainSocketImpl.connectToAddress(AbstractPlainSocketImpl.java:200)
	at java.net.AbstractPlainSocketImpl.connect(AbstractPlainSocketImpl.java:182)
	at java.net.SocksSocketImpl.connect(SocksSocketImpl.java:392)
	at java.net.Socket.connect(Socket.java:579)
	at hidden.jth.org.apache.http.conn.socket.PlainConnectionSocketFactory.connectSocket(PlainConnectionSocketFactory.java:74)
	at hidden.jth.org.apache.http.impl.conn.DefaultHttpClientConnectionOperator.connect(DefaultHttpClientConnectionOperator.java:134)
	at hidden.jth.org.apache.http.impl.conn.PoolingHttpClientConnectionManager.connect(PoolingHttpClientConnectionManager.java:353)
	at hidden.jth.org.apache.http.impl.execchain.MainClientExec.establishRoute(MainClientExec.java:380)
	at hidden.jth.org.apache.http.impl.execchain.MainClientExec.execute(MainClientExec.java:236)
	at hidden.jth.org.apache.http.impl.execchain.ProtocolExec.execute(ProtocolExec.java:184)
	at hidden.jth.org.apache.http.impl.execchain.RetryExec.execute(RetryExec.java:88)
	at hidden.jth.org.apache.http.impl.execchain.RedirectExec.execute(RedirectExec.java:110)
	at hidden.jth.org.apache.http.impl.client.InternalHttpClient.doExecute(InternalHttpClient.java:184)
	at hidden.jth.org.apache.http.impl.client.CloseableHttpClient.execute(CloseableHttpClient.java:71)
	at com.gargoylesoftware.htmlunit.HttpWebConnection.getResponse(HttpWebConnection.java:179)
	at com.gargoylesoftware.htmlunit.WebClient.loadWebResponseFromWebConnection(WebClient.java:1321)
	at com.gargoylesoftware.htmlunit.WebClient.loadWebResponse(WebClient.java:1238)
	at org.jvnet.hudson.test.JenkinsRule$WebClient.loadWebResponse(JenkinsRule.java:2032)
	at com.gargoylesoftware.htmlunit.html.HtmlPage.loadJavaScriptFromUrl(HtmlPage.java:1066)
	at com.gargoylesoftware.htmlunit.html.HtmlPage.loadExternalJavaScriptFile(HtmlPage.java:1009)
	at com.gargoylesoftware.htmlunit.html.HtmlScript.executeScriptIfNeeded(HtmlScript.java:395)
	at com.gargoylesoftware.htmlunit.html.HtmlScript$3.execute(HtmlScript.java:276)
	at com.gargoylesoftware.htmlunit.javascript.JavaScriptEngine.doProcessPostponedActions(JavaScriptEngine.java:913)
	at com.gargoylesoftware.htmlunit.javascript.JavaScriptEngine.access$500(JavaScriptEngine.java:105)
	at com.gargoylesoftware.htmlunit.javascript.JavaScriptEngine$HtmlUnitContextAction.run(JavaScriptEngine.java:860)
	at net.sourceforge.htmlunit.corejs.javascript.Context.call(Context.java:628)
	at net.sourceforge.htmlunit.corejs.javascript.ContextFactory.call(ContextFactory.java:513)
	at com.gargoylesoftware.htmlunit.javascript.JavaScriptEngine.callFunction(JavaScriptEngine.java:796)
	at com.gargoylesoftware.htmlunit.javascript.JavaScriptEngine.callFunction(JavaScriptEngine.java:768)
	at com.gargoylesoftware.htmlunit.InteractivePage.executeJavaScriptFunctionIfPossible(InteractivePage.java:201)
	at com.gargoylesoftware.htmlunit.javascript.host.event.EventListenersContainer.executeEventHandler(EventListenersContainer.java:235)
	at com.gargoylesoftware.htmlunit.javascript.host.event.EventListenersContainer.executeBubblingListeners(EventListenersContainer.java:255)
	at com.gargoylesoftware.htmlunit.javascript.host.event.EventTarget.fireEvent(EventTarget.java:205)
	at com.gargoylesoftware.htmlunit.html.DomElement$2.run(DomElement.java:1161)
	at net.sourceforge.htmlunit.corejs.javascript.Context.call(Context.java:628)
	at net.sourceforge.htmlunit.corejs.javascript.ContextFactory.call(ContextFactory.java:513)
	at com.gargoylesoftware.htmlunit.html.DomElement.fireEvent(DomElement.java:1166)
	at com.gargoylesoftware.htmlunit.html.HtmlPage.executeEventHandlersIfNeeded(HtmlPage.java:1252)
	at com.gargoylesoftware.htmlunit.html.HtmlPage.initialize(HtmlPage.java:274)
	at com.gargoylesoftware.htmlunit.WebClient.loadWebResponseInto(WebClient.java:483)
	at com.gargoylesoftware.htmlunit.WebClient.getPage(WebClient.java:350)
	at com.gargoylesoftware.htmlunit.WebClient.getPage(WebClient.java:415)
	at com.gargoylesoftware.htmlunit.WebClient.getPage(WebClient.java:400)
	at org.jvnet.hudson.test.JenkinsRule$WebClient.goTo(JenkinsRule.java:2227)
	at org.jvnet.hudson.test.JenkinsRule$WebClient.goTo(JenkinsRule.java:2207)
	at org.jvnet.hudson.test.JenkinsRule$WebClient.getPage(JenkinsRule.java:2163)
	at org.jvnet.hudson.test.JenkinsRule.configRoundtrip(JenkinsRule.java:1082)
	at org.jenkinsci.plugins.credentialsbinding.impl.SecretBuildWrapperTest.emptySecretsList(SecretBuildWrapperTest.java:92)
[...]
```

The stack does not obviously show that it is a request to `usage.jenkins.io`, but I've
made a sysdig capture during tests execution, and the target IP was `52.204.62.78`.

Note: sure, if there are some reasons to keep .3 rather than .4, then feel free to close this PR. Now that I've understood the issue, it is easy to workaround in my working copy...