### PR TITLE
[FIXED JENKINS-42999] Allow bindings to specify their required context

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-step-api</artifactId>
-      <version>2.4</version>
+      <version>2.9</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>

--- a/src/main/java/org/jenkinsci/plugins/credentialsbinding/Binding.java
+++ b/src/main/java/org/jenkinsci/plugins/credentialsbinding/Binding.java
@@ -35,6 +35,7 @@ import hudson.model.BuildListener;
 import java.io.IOException;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 import hudson.model.Run;
 import hudson.model.TaskListener;
@@ -104,8 +105,18 @@ public abstract class Binding<C extends StandardCredentials> extends MultiBindin
         };
     }
 
-    /** Sets up bindings for a build. */
-    public /* abstract */SingleEnvironment bindSingle(@Nonnull Run<?,?> build, FilePath workspace, Launcher launcher, TaskListener listener) throws IOException, InterruptedException {
+    /**
+     * Sets up bindings for a build.
+     * @param build The build. Cannot be null
+     * @param workspace The workspace - can be null if {@link BindingDescriptor#requiresWorkspace()} is false.
+     * @param launcher The launcher - can be null if {@link BindingDescriptor#requiresWorkspace()} is false.
+     * @param listener The task listener. Cannot be null.
+     * @return The configured {@link SingleEnvironment}
+     */
+    public /* abstract */SingleEnvironment bindSingle(@Nonnull Run<?,?> build,
+                                                      @Nullable FilePath workspace,
+                                                      @Nullable Launcher launcher,
+                                                      @Nonnull TaskListener listener) throws IOException, InterruptedException {
         if (Util.isOverridden(Binding.class, getClass(), "bind", AbstractBuild.class, Launcher.class, BuildListener.class) && build instanceof AbstractBuild && listener instanceof BuildListener) {
             Environment e = bind((AbstractBuild) build, launcher, (BuildListener) listener);
             return new SingleEnvironment(e.value(), new UnbinderWrapper(e));
@@ -123,13 +134,19 @@ public abstract class Binding<C extends StandardCredentials> extends MultiBindin
         UnbinderWrapper(Environment e) {
             this.e = e;
         }
-        @Override public void unbind(Run<?, ?> build, FilePath workspace, Launcher launcher, TaskListener listener) throws IOException, InterruptedException {
+        @Override public void unbind(@Nonnull Run<?, ?> build,
+                                     @Nullable FilePath workspace,
+                                     @Nullable Launcher launcher,
+                                     @Nonnull TaskListener listener) throws IOException, InterruptedException {
             e.unbind();
         }
     }
 
 
-    @Override public final MultiEnvironment bind(Run<?,?> build, FilePath workspace, Launcher launcher, TaskListener listener) throws IOException, InterruptedException {
+    @Override public final MultiEnvironment bind(@Nonnull Run<?,?> build,
+                                                 @Nullable FilePath workspace,
+                                                 @Nullable Launcher launcher,
+                                                 @Nonnull TaskListener listener) throws IOException, InterruptedException {
         SingleEnvironment single = bindSingle(build, workspace, launcher, listener);
         return new MultiEnvironment(Collections.singletonMap(variable, single.value), single.unbinder);
     }

--- a/src/main/java/org/jenkinsci/plugins/credentialsbinding/BindingDescriptor.java
+++ b/src/main/java/org/jenkinsci/plugins/credentialsbinding/BindingDescriptor.java
@@ -29,11 +29,21 @@ import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.common.AbstractIdCredentialsListBoxModel;
 import com.cloudbees.plugins.credentials.common.StandardCredentials;
 import com.cloudbees.plugins.credentials.domains.DomainRequirement;
+import hudson.FilePath;
+import hudson.Launcher;
 import hudson.model.Descriptor;
 import hudson.model.Item;
+import hudson.model.Run;
+import hudson.model.TaskListener;
 import hudson.security.ACL;
 import hudson.util.ListBoxModel;
+
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.kohsuke.stapler.AncestorInPath;
 
 /**
@@ -43,6 +53,19 @@ import org.kohsuke.stapler.AncestorInPath;
 public abstract class BindingDescriptor<C extends StandardCredentials> extends Descriptor<MultiBinding<C>> {
 
     protected abstract Class<C> type();
+
+    /**
+     * Returns the context {@link MultiBinding} needs to access. Defaults to {@link Run}, {@link FilePath},
+     * {@link Launcher} and {@link TaskListener}.
+     *
+     * This allows the system to statically infer which steps are applicable in which context
+     * (say in freestyle or in workflow).
+     * @see StepContext#get(Class)
+     */
+    public Set<? extends Class<?>> getRequiredContext() {
+        return Collections.unmodifiableSet(new HashSet<Class<?>>(Arrays.asList(Run.class, FilePath.class, Launcher.class,
+                TaskListener.class)));
+    }
 
     public ListBoxModel doFillCredentialsIdItems(@AncestorInPath Item owner) {
         if (owner == null || !owner.hasPermission(Item.CONFIGURE)) {

--- a/src/main/java/org/jenkinsci/plugins/credentialsbinding/BindingDescriptor.java
+++ b/src/main/java/org/jenkinsci/plugins/credentialsbinding/BindingDescriptor.java
@@ -29,21 +29,13 @@ import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.common.AbstractIdCredentialsListBoxModel;
 import com.cloudbees.plugins.credentials.common.StandardCredentials;
 import com.cloudbees.plugins.credentials.domains.DomainRequirement;
-import hudson.FilePath;
-import hudson.Launcher;
 import hudson.model.Descriptor;
 import hudson.model.Item;
-import hudson.model.Run;
-import hudson.model.TaskListener;
 import hudson.security.ACL;
 import hudson.util.ListBoxModel;
 
-import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashSet;
-import java.util.Set;
 
-import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.kohsuke.stapler.AncestorInPath;
 
 /**
@@ -55,16 +47,10 @@ public abstract class BindingDescriptor<C extends StandardCredentials> extends D
     protected abstract Class<C> type();
 
     /**
-     * Returns the context {@link MultiBinding} needs to access. Defaults to {@link Run}, {@link FilePath},
-     * {@link Launcher} and {@link TaskListener}.
-     *
-     * This allows the system to statically infer which steps are applicable in which context
-     * (say in freestyle or in workflow).
-     * @see StepContext#get(Class)
+     * Determines whether this {@link MultiBinding} needs a workspace to evaluate.
      */
-    public Set<? extends Class<?>> getRequiredContext() {
-        return Collections.unmodifiableSet(new HashSet<Class<?>>(Arrays.asList(Run.class, FilePath.class, Launcher.class,
-                TaskListener.class)));
+    public boolean requiresWorkspace() {
+        return true;
     }
 
     public ListBoxModel doFillCredentialsIdItems(@AncestorInPath Item owner) {

--- a/src/main/java/org/jenkinsci/plugins/credentialsbinding/MultiBinding.java
+++ b/src/main/java/org/jenkinsci/plugins/credentialsbinding/MultiBinding.java
@@ -47,6 +47,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 import hudson.util.Secret;
 import jenkins.model.Jenkins;
@@ -103,18 +104,40 @@ public abstract class MultiBinding<C extends StandardCredentials> extends Abstra
 
     /** Callback run at the end of a build. */
     public interface Unbinder extends Serializable {
-        /** Performs any needed cleanup. */
-        void unbind(@Nonnull Run<?,?> build, FilePath workspace, Launcher launcher, TaskListener listener) throws IOException, InterruptedException;
+        /**
+         * Performs any needed cleanup.
+         * @param build The build. Cannot be null
+         * @param workspace The workspace - can be null if {@link BindingDescriptor#requiresWorkspace()} is false.
+         * @param launcher The launcher - can be null if {@link BindingDescriptor#requiresWorkspace()} is false.
+         * @param listener The task listener. Cannot be null.
+         */
+        void unbind(@Nonnull Run<?,?> build,
+                    @Nullable FilePath workspace,
+                    @Nullable Launcher launcher,
+                    @Nonnull TaskListener listener) throws IOException, InterruptedException;
     }
 
     /** No-op callback. */
     protected static final class NullUnbinder implements Unbinder {
         private static final long serialVersionUID = 1;
-        @Override public void unbind(Run<?, ?> build, FilePath workspace, Launcher launcher, TaskListener listener) throws IOException, InterruptedException {}
+        @Override public void unbind(@Nonnull Run<?, ?> build,
+                                     @Nullable FilePath workspace,
+                                     @Nullable Launcher launcher,
+                                     @Nonnull TaskListener listener) throws IOException, InterruptedException {}
     }
 
-    /** Sets up bindings for a build. */
-    public abstract MultiEnvironment bind(@Nonnull Run<?,?> build, FilePath workspace, Launcher launcher, TaskListener listener) throws IOException, InterruptedException;
+    /**
+     * Sets up bindings for a build.
+     * @param build The build. Cannot be null
+     * @param workspace The workspace - can be null if {@link BindingDescriptor#requiresWorkspace()} is false.
+     * @param launcher The launcher - can be null if {@link BindingDescriptor#requiresWorkspace()} is false.
+     * @param listener The task listener. Cannot be null.
+     * @return The configured {@link MultiEnvironment}
+     */
+    public abstract MultiEnvironment bind(@Nonnull Run<?,?> build,
+                                          @Nullable FilePath workspace,
+                                          @Nullable Launcher launcher,
+                                          @Nonnull TaskListener listener) throws IOException, InterruptedException;
 
     /** Defines keys expected to be set in {@link MultiEnvironment#getValues}, particularly any that might be sensitive. */
     public abstract Set<String> variables();

--- a/src/main/java/org/jenkinsci/plugins/credentialsbinding/impl/BindingStep.java
+++ b/src/main/java/org/jenkinsci/plugins/credentialsbinding/impl/BindingStep.java
@@ -101,10 +101,13 @@ public final class BindingStep extends Step {
             if (run == null) {
                 throw new MissingContextVariableException(Run.class);
             }
+            TaskListener listener = getContext().get(TaskListener.class);
+            if (listener == null) {
+                throw new MissingContextVariableException(TaskListener.class);
+            }
 
             FilePath workspace = getContext().get(FilePath.class);
             Launcher launcher = getContext().get(Launcher.class);
-            TaskListener listener = getContext().get(TaskListener.class);
 
             Map<String,String> overrides = new HashMap<String,String>();
             List<MultiBinding.Unbinder> unbinders = new ArrayList<MultiBinding.Unbinder>();

--- a/src/main/java/org/jenkinsci/plugins/credentialsbinding/impl/BindingStep.java
+++ b/src/main/java/org/jenkinsci/plugins/credentialsbinding/impl/BindingStep.java
@@ -107,7 +107,8 @@ public final class BindingStep extends Step {
             Map<String,String> overrides = new HashMap<String,String>();
             List<MultiBinding.Unbinder> unbinders = new ArrayList<MultiBinding.Unbinder>();
             for (MultiBinding<?> binding : step.bindings) {
-                if (binding.getDescriptor().requiresWorkspace() && workspace == null) {
+                if (binding.getDescriptor().requiresWorkspace() &&
+                        (workspace == null || launcher == null)) {
                     throw new MissingContextVariableException(FilePath.class);
                 }
                 MultiBinding.MultiEnvironment environment = binding.bind(run, workspace, launcher, listener);
@@ -198,14 +199,10 @@ public final class BindingStep extends Step {
 
         @Override protected void finished(StepContext context) throws Exception {
             Exception xx = null;
-            Run<?,?> run = context.get(Run.class);
-            if (run == null) {
-                throw new MissingContextVariableException(Run.class);
-            }
 
             for (MultiBinding.Unbinder unbinder : unbinders) {
                 try {
-                    unbinder.unbind(run, context.get(FilePath.class), context.get(Launcher.class), context.get(TaskListener.class));
+                    unbinder.unbind(context.get(Run.class), context.get(FilePath.class), context.get(Launcher.class), context.get(TaskListener.class));
                 } catch (Exception x) {
                     if (xx == null) {
                         xx = x;

--- a/src/main/java/org/jenkinsci/plugins/credentialsbinding/impl/FileBinding.java
+++ b/src/main/java/org/jenkinsci/plugins/credentialsbinding/impl/FileBinding.java
@@ -39,6 +39,8 @@ import org.jenkinsci.plugins.credentialsbinding.BindingDescriptor;
 import org.jenkinsci.plugins.plaincredentials.FileCredentials;
 import org.kohsuke.stapler.DataBoundConstructor;
 
+import javax.annotation.Nonnull;
+
 public class FileBinding extends Binding<FileCredentials> {
 
     @DataBoundConstructor public FileBinding(String variable, String credentialsId) {
@@ -79,7 +81,7 @@ public class FileBinding extends Binding<FileCredentials> {
             this.dirName = dirName;
         }
         
-        @Override public void unbind(Run<?, ?> build, FilePath workspace, Launcher launcher, TaskListener listener) throws IOException, InterruptedException {
+        @Override public void unbind(@Nonnull Run<?, ?> build, FilePath workspace, Launcher launcher, TaskListener listener) throws IOException, InterruptedException {
             secretsDir(workspace).child(dirName).deleteRecursive();
         }
         

--- a/src/main/java/org/jenkinsci/plugins/credentialsbinding/impl/StringBinding.java
+++ b/src/main/java/org/jenkinsci/plugins/credentialsbinding/impl/StringBinding.java
@@ -43,6 +43,7 @@ import org.jenkinsci.plugins.plaincredentials.StringCredentials;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 public class StringBinding extends Binding<StringCredentials> {
 
@@ -54,15 +55,18 @@ public class StringBinding extends Binding<StringCredentials> {
         return StringCredentials.class;
     }
 
-    @Override public SingleEnvironment bindSingle(@Nonnull Run<?,?> build, FilePath workspace, Launcher launcher, TaskListener listener) throws IOException, InterruptedException {
+    @Override public SingleEnvironment bindSingle(@Nonnull Run<?,?> build,
+                                                  @Nullable FilePath workspace,
+                                                  @Nullable Launcher launcher,
+                                                  @Nonnull TaskListener listener) throws IOException, InterruptedException {
         return new SingleEnvironment(getCredentials(build).getSecret().getPlainText());
     }
 
     @Symbol("string")
     @Extension public static class DescriptorImpl extends BindingDescriptor<StringCredentials> {
 
-        @Override public Set<? extends Class<?>> getRequiredContext() {
-            return Collections.unmodifiableSet(new HashSet<>(Arrays.asList(Run.class, TaskListener.class)));
+        @Override public boolean requiresWorkspace() {
+            return false;
         }
 
         @Override protected Class<StringCredentials> type() {

--- a/src/main/java/org/jenkinsci/plugins/credentialsbinding/impl/StringBinding.java
+++ b/src/main/java/org/jenkinsci/plugins/credentialsbinding/impl/StringBinding.java
@@ -30,12 +30,19 @@ import hudson.Launcher;
 import hudson.model.Run;
 import hudson.model.TaskListener;
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
 import org.jenkinsci.Symbol;
 
 import org.jenkinsci.plugins.credentialsbinding.Binding;
 import org.jenkinsci.plugins.credentialsbinding.BindingDescriptor;
 import org.jenkinsci.plugins.plaincredentials.StringCredentials;
 import org.kohsuke.stapler.DataBoundConstructor;
+
+import javax.annotation.Nonnull;
 
 public class StringBinding extends Binding<StringCredentials> {
 
@@ -47,12 +54,16 @@ public class StringBinding extends Binding<StringCredentials> {
         return StringCredentials.class;
     }
 
-    @Override public SingleEnvironment bindSingle(Run<?,?> build, FilePath workspace, Launcher launcher, TaskListener listener) throws IOException, InterruptedException {
+    @Override public SingleEnvironment bindSingle(@Nonnull Run<?,?> build, FilePath workspace, Launcher launcher, TaskListener listener) throws IOException, InterruptedException {
         return new SingleEnvironment(getCredentials(build).getSecret().getPlainText());
     }
 
     @Symbol("string")
     @Extension public static class DescriptorImpl extends BindingDescriptor<StringCredentials> {
+
+        @Override public Set<? extends Class<?>> getRequiredContext() {
+            return Collections.unmodifiableSet(new HashSet<>(Arrays.asList(Run.class, TaskListener.class)));
+        }
 
         @Override protected Class<StringCredentials> type() {
             return StringCredentials.class;

--- a/src/main/java/org/jenkinsci/plugins/credentialsbinding/impl/UsernamePasswordBinding.java
+++ b/src/main/java/org/jenkinsci/plugins/credentialsbinding/impl/UsernamePasswordBinding.java
@@ -43,6 +43,7 @@ import org.jenkinsci.plugins.credentialsbinding.BindingDescriptor;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 public class UsernamePasswordBinding extends Binding<StandardUsernamePasswordCredentials> {
 
@@ -54,7 +55,10 @@ public class UsernamePasswordBinding extends Binding<StandardUsernamePasswordCre
         return StandardUsernamePasswordCredentials.class;
     }
 
-    @Override public SingleEnvironment bindSingle(@Nonnull Run<?,?> build, FilePath workspace, Launcher launcher, TaskListener listener) throws IOException, InterruptedException {
+    @Override public SingleEnvironment bindSingle(@Nonnull Run<?,?> build,
+                                                  @Nullable FilePath workspace,
+                                                  @Nullable Launcher launcher,
+                                                  @Nonnull TaskListener listener) throws IOException, InterruptedException {
         StandardUsernamePasswordCredentials credentials = getCredentials(build);
         return new SingleEnvironment(credentials.getUsername() + ':' + credentials.getPassword().getPlainText());
     }
@@ -70,8 +74,8 @@ public class UsernamePasswordBinding extends Binding<StandardUsernamePasswordCre
             return Messages.UsernamePasswordBinding_username_and_password();
         }
 
-        @Override public Set<? extends Class<?>> getRequiredContext() {
-            return Collections.unmodifiableSet(new HashSet<>(Arrays.asList(Run.class, TaskListener.class)));
+        @Override public boolean requiresWorkspace() {
+            return false;
         }
     }
 

--- a/src/main/java/org/jenkinsci/plugins/credentialsbinding/impl/UsernamePasswordBinding.java
+++ b/src/main/java/org/jenkinsci/plugins/credentialsbinding/impl/UsernamePasswordBinding.java
@@ -31,11 +31,18 @@ import hudson.Launcher;
 import hudson.model.Run;
 import hudson.model.TaskListener;
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
 import org.jenkinsci.Symbol;
 
 import org.jenkinsci.plugins.credentialsbinding.Binding;
 import org.jenkinsci.plugins.credentialsbinding.BindingDescriptor;
 import org.kohsuke.stapler.DataBoundConstructor;
+
+import javax.annotation.Nonnull;
 
 public class UsernamePasswordBinding extends Binding<StandardUsernamePasswordCredentials> {
 
@@ -47,7 +54,7 @@ public class UsernamePasswordBinding extends Binding<StandardUsernamePasswordCre
         return StandardUsernamePasswordCredentials.class;
     }
 
-    @Override public SingleEnvironment bindSingle(Run<?,?> build, FilePath workspace, Launcher launcher, TaskListener listener) throws IOException, InterruptedException {
+    @Override public SingleEnvironment bindSingle(@Nonnull Run<?,?> build, FilePath workspace, Launcher launcher, TaskListener listener) throws IOException, InterruptedException {
         StandardUsernamePasswordCredentials credentials = getCredentials(build);
         return new SingleEnvironment(credentials.getUsername() + ':' + credentials.getPassword().getPlainText());
     }
@@ -63,6 +70,9 @@ public class UsernamePasswordBinding extends Binding<StandardUsernamePasswordCre
             return Messages.UsernamePasswordBinding_username_and_password();
         }
 
+        @Override public Set<? extends Class<?>> getRequiredContext() {
+            return Collections.unmodifiableSet(new HashSet<>(Arrays.asList(Run.class, TaskListener.class)));
+        }
     }
 
 }

--- a/src/main/java/org/jenkinsci/plugins/credentialsbinding/impl/UsernamePasswordMultiBinding.java
+++ b/src/main/java/org/jenkinsci/plugins/credentialsbinding/impl/UsernamePasswordMultiBinding.java
@@ -44,6 +44,7 @@ import org.jenkinsci.plugins.credentialsbinding.MultiBinding;
 import org.kohsuke.stapler.DataBoundConstructor;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 public class UsernamePasswordMultiBinding extends MultiBinding<StandardUsernamePasswordCredentials> {
 
@@ -68,7 +69,10 @@ public class UsernamePasswordMultiBinding extends MultiBinding<StandardUsernameP
         return StandardUsernamePasswordCredentials.class;
     }
 
-    @Override public MultiEnvironment bind(@Nonnull Run<?, ?> build, FilePath workspace, Launcher launcher, TaskListener listener) throws IOException, InterruptedException {
+    @Override public MultiEnvironment bind(@Nonnull Run<?, ?> build,
+                                           @Nullable FilePath workspace,
+                                           @Nullable Launcher launcher,
+                                           @Nonnull TaskListener listener) throws IOException, InterruptedException {
         StandardUsernamePasswordCredentials credentials = getCredentials(build);
         Map<String,String> m = new HashMap<String,String>();
         m.put(usernameVariable, credentials.getUsername());
@@ -91,8 +95,8 @@ public class UsernamePasswordMultiBinding extends MultiBinding<StandardUsernameP
             return Messages.UsernamePasswordMultiBinding_username_and_password();
         }
 
-        @Override public Set<? extends Class<?>> getRequiredContext() {
-            return Collections.unmodifiableSet(new HashSet<>(Arrays.asList(Run.class, TaskListener.class)));
+        @Override public boolean requiresWorkspace() {
+            return false;
         }
     }
 

--- a/src/main/java/org/jenkinsci/plugins/credentialsbinding/impl/UsernamePasswordMultiBinding.java
+++ b/src/main/java/org/jenkinsci/plugins/credentialsbinding/impl/UsernamePasswordMultiBinding.java
@@ -32,6 +32,7 @@ import hudson.model.Run;
 import hudson.model.TaskListener;
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -41,6 +42,8 @@ import org.jenkinsci.Symbol;
 import org.jenkinsci.plugins.credentialsbinding.BindingDescriptor;
 import org.jenkinsci.plugins.credentialsbinding.MultiBinding;
 import org.kohsuke.stapler.DataBoundConstructor;
+
+import javax.annotation.Nonnull;
 
 public class UsernamePasswordMultiBinding extends MultiBinding<StandardUsernamePasswordCredentials> {
 
@@ -65,7 +68,7 @@ public class UsernamePasswordMultiBinding extends MultiBinding<StandardUsernameP
         return StandardUsernamePasswordCredentials.class;
     }
 
-    @Override public MultiEnvironment bind(Run<?, ?> build, FilePath workspace, Launcher launcher, TaskListener listener) throws IOException, InterruptedException {
+    @Override public MultiEnvironment bind(@Nonnull Run<?, ?> build, FilePath workspace, Launcher launcher, TaskListener listener) throws IOException, InterruptedException {
         StandardUsernamePasswordCredentials credentials = getCredentials(build);
         Map<String,String> m = new HashMap<String,String>();
         m.put(usernameVariable, credentials.getUsername());
@@ -88,6 +91,9 @@ public class UsernamePasswordMultiBinding extends MultiBinding<StandardUsernameP
             return Messages.UsernamePasswordMultiBinding_username_and_password();
         }
 
+        @Override public Set<? extends Class<?>> getRequiredContext() {
+            return Collections.unmodifiableSet(new HashSet<>(Arrays.asList(Run.class, TaskListener.class)));
+        }
     }
 
 }

--- a/src/test/java/org/jenkinsci/plugins/credentialsbinding/impl/BindingStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/credentialsbinding/impl/BindingStepTest.java
@@ -165,6 +165,75 @@ public class BindingStepTest {
         });
     }
 
+    @Issue("JENKINS-42999")
+    @Test
+    public void limitedRequiredContext() throws Exception {
+        final String credentialsId = "creds";
+        final String username = "bob";
+        final String password = "s3cr3t";
+        story.addStep(new Statement() {
+            @Override public void evaluate() throws Throwable {
+                UsernamePasswordCredentialsImpl c = new UsernamePasswordCredentialsImpl(CredentialsScope.GLOBAL, credentialsId, "sample", username, password);
+                CredentialsProvider.lookupStores(story.j.jenkins).iterator().next().addCredentials(Domain.global(), c);
+                WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, "p");
+                p.setDefinition(new CpsFlowDefinition(""
+                        + "withCredentials([usernamePassword(usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD', credentialsId: '" + credentialsId + "')]) {\n"
+                        + "  node {\n"  // We still need to enter a node to get the actual creds via the file.
+                        + "    semaphore 'basics'\n"
+                        + "    sh '''\n"
+                        + "      set +x\n"
+                        + "      echo curl -u $USERNAME:$PASSWORD server > script.sh\n"
+                        + "    '''\n"
+                        + "  }\n"
+                        + "}", true));
+                WorkflowRun b = p.scheduleBuild2(0).waitForStart();
+                SemaphoreStep.waitForStart("basics/1", b);
+            }
+        });
+        story.addStep(new Statement() {
+            @Override public void evaluate() throws Throwable {
+                WorkflowJob p = story.j.jenkins.getItemByFullName("p", WorkflowJob.class);
+                assertNotNull(p);
+                WorkflowRun b = p.getBuildByNumber(1);
+                assertNotNull(b);
+                assertEquals(Collections.<String>emptySet(), grep(b.getRootDir(), password));
+                SemaphoreStep.success("basics/1", null);
+                story.j.waitForCompletion(b);
+                story.j.assertBuildStatusSuccess(b);
+                story.j.assertLogNotContains(password, b);
+                FilePath script = story.j.jenkins.getWorkspaceFor(p).child("script.sh");
+                assertTrue(script.exists());
+                assertEquals("curl -u " + username + ":" + password + " server", script.readToString().trim());
+                assertEquals(Collections.<String>emptySet(), grep(b.getRootDir(), password));
+            }
+        });
+    }
+
+    @Issue("JENKINS-42999")
+    @Test
+    public void widerRequiredContext() throws Exception {
+        final String credentialsId = "creds";
+        final String credsFile = "credsFile";
+        final String credsContent = "s3cr3t";
+        story.addStep(new Statement() {
+            @Override public void evaluate() throws Throwable {
+                FileCredentialsImpl c = new FileCredentialsImpl(CredentialsScope.GLOBAL, credentialsId, "sample", credsFile, SecretBytes.fromBytes(credsContent.getBytes()));
+                CredentialsProvider.lookupStores(story.j.jenkins).iterator().next().addCredentials(Domain.global(), c);
+                WorkflowJob p = story.j.jenkins.createProject(WorkflowJob.class, "p");
+                p.setDefinition(new CpsFlowDefinition(""
+                        + "withCredentials([file(variable: 'targetFile', credentialsId: '" + credentialsId + "')]) {\n"
+                        + "  echo 'We should fail before getting here'\n"
+                        + "}", true));
+                WorkflowRun b = p.scheduleBuild2(0).waitForStart();
+                story.j.assertBuildStatus(Result.FAILURE, story.j.waitForCompletion(b));
+                story.j.assertLogNotContains("We should fail before getting here", b);
+                // We can't guarantee whether this will fail due to missing FilePath.class or Launcher.class.
+                // So look for the follow-up error instead.
+                story.j.assertLogContains("Perhaps you forgot to surround the code with a step that provides this, such as: node", b);
+            }
+        });
+    }
+
     @Inject
     StringCredentialsImpl.DescriptorImpl stringCredentialsDescriptor;
 


### PR DESCRIPTION
[JENKINS-42999](https://issues.jenkins-ci.org/browse/JENKINS-42999)

Not all bindings require a workspace, and those that don't should be
able to be used in `withCredentials` outside of a `node` block. This
adds `BindingDescriptor.getRequiredContext()`, defaulting to the four
contexts that were previously required by `BindingStep`, but allowing
override. `BindingStep` will now throw a
`MissingContextVariableException` if any of the `MultiBinding`s used
have a required context that cannot be satisfied, as well as the
normal potential `MissingContextVariableException` for `BindingStep.DescriptorImpl.getRequiredContext()`.

In addition, bumped `workflow-step-api` to 2.9 and moved `BindingStep`
and friends to non-deprecated code paths while I was here.

cc @reviewbybees esp @jglick @stephenc @rsandell 