### PR TITLE
Ease writing of new on-disk Binding implementations (take 2)

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/credentialsbinding/impl/AbstractOnDiskBinding.java
+++ b/src/main/java/org/jenkinsci/plugins/credentialsbinding/impl/AbstractOnDiskBinding.java
@@ -1,0 +1,84 @@
+package org.jenkinsci.plugins.credentialsbinding.impl;
+
+import java.io.IOException;
+import java.util.UUID;
+
+import javax.annotation.Nonnull;
+
+import org.jenkinsci.plugins.credentialsbinding.Binding;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+import com.cloudbees.plugins.credentials.common.StandardCredentials;
+
+import hudson.FilePath;
+import hudson.Launcher;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import hudson.slaves.WorkspaceList;
+
+/**
+ * Base class for writing credentials to a file or directory, and binding its path to a single variable. Handles
+ * creation of a -rwx------ temporary directory, and its full deletion when unbinding.
+ * @param <C> a kind of credentials
+ */
+public abstract class AbstractOnDiskBinding<C extends StandardCredentials> extends Binding<C> {
+
+    protected AbstractOnDiskBinding(String variable, String credentialsId) {
+        super(variable, credentialsId);
+    }
+
+    @Override
+    public final SingleEnvironment bindSingle(@Nonnull Run<?, ?> build,
+                                              FilePath workspace,
+                                              Launcher launcher,
+                                              @Nonnull TaskListener listener) throws IOException, InterruptedException {
+        final FilePath secrets = secretsDir(workspace);
+        final String dirName = UUID.randomUUID().toString();
+        final FilePath dir = secrets.child(dirName);
+        dir.mkdirs();
+        secrets.chmod(0700);
+        dir.chmod(0700);
+        final FilePath secret = write(getCredentials(build), dir);
+        return new SingleEnvironment(secret.getRemote(), new UnbinderImpl(dirName));
+    }
+
+    /**
+     * Writes credentials under a given temporary directory, and returns their path (will be bound to the variable).
+     * @param credentials the credentials to bind
+     * @param dir a temporary directory where credentials should be written. You can assume it has already been created,
+     *            with secure permissions.
+     * @return the path to the on-disk credentials, to be bound to the variable
+     * @throws IOException
+     * @throws InterruptedException
+     */
+    abstract protected FilePath write(C credentials, FilePath dir) throws IOException, InterruptedException;
+
+    @Restricted(NoExternalUse.class)
+    protected static class UnbinderImpl implements Unbinder {
+        private static final long serialVersionUID = 1;
+        private final String dirName;
+
+        protected UnbinderImpl(String dirName) {
+            this.dirName = dirName;
+        }
+
+        @Override
+        public void unbind(@Nonnull Run<?, ?> build,
+                           FilePath workspace,
+                           Launcher launcher,
+                           @Nonnull TaskListener listener) throws IOException, InterruptedException {
+            secretsDir(workspace).child(dirName).deleteRecursive();
+        }
+    }
+
+    private static FilePath secretsDir(FilePath workspace) {
+        return tempDir(workspace).child("secretFiles");
+    }
+
+    // TODO 1.652 use WorkspaceList.tempDir
+    private static FilePath tempDir(FilePath ws) {
+        return ws.sibling(ws.getName() + System.getProperty(WorkspaceList.class.getName(), "@") + "tmp");
+    }
+
+}

--- a/src/main/java/org/jenkinsci/plugins/credentialsbinding/impl/FileBinding.java
+++ b/src/main/java/org/jenkinsci/plugins/credentialsbinding/impl/FileBinding.java
@@ -67,7 +67,7 @@ public class FileBinding extends AbstractOnDiskBinding<FileCredentials> {
         }
 
         protected Object readResolve() {
-            return new AbstractOnDiskBinding.UnbinderImpl(dirName);
+            return new UnbindableDir.UnbinderImpl(dirName);
         }
 
         @Override
@@ -75,7 +75,7 @@ public class FileBinding extends AbstractOnDiskBinding<FileCredentials> {
                            FilePath workspace,
                            Launcher launcher,
                            @Nonnull TaskListener listener) throws IOException, InterruptedException {
-            // replaced by the AbstractOnDiskBinding.UnbinderImpl implementation
+            // replaced by the UnbindableDir.UnbinderImpl implementation
         }
     }
 

--- a/src/main/java/org/jenkinsci/plugins/credentialsbinding/impl/FileBinding.java
+++ b/src/main/java/org/jenkinsci/plugins/credentialsbinding/impl/FileBinding.java
@@ -29,21 +29,17 @@ import hudson.FilePath;
 import hudson.Launcher;
 import hudson.model.Run;
 import hudson.model.TaskListener;
-import hudson.slaves.WorkspaceList;
-import java.io.IOException;
-import java.util.UUID;
-import org.jenkinsci.Symbol;
 
-import org.jenkinsci.plugins.credentialsbinding.Binding;
+import java.io.IOException;
+
+import org.jenkinsci.Symbol;
 import org.jenkinsci.plugins.credentialsbinding.BindingDescriptor;
 import org.jenkinsci.plugins.plaincredentials.FileCredentials;
 import org.kohsuke.stapler.DataBoundConstructor;
 
-import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 
-public class FileBinding extends Binding<FileCredentials> {
+public class FileBinding extends AbstractOnDiskBinding<FileCredentials> {
 
     @DataBoundConstructor public FileBinding(String variable, String credentialsId) {
         super(variable, credentialsId);
@@ -53,58 +49,34 @@ public class FileBinding extends Binding<FileCredentials> {
         return FileCredentials.class;
     }
 
-    @Override public SingleEnvironment bindSingle(@Nonnull Run<?,?> build,
-                                                  FilePath workspace,
-                                                  Launcher launcher,
-                                                  @Nonnull TaskListener listener) throws IOException, InterruptedException {
-        FileCredentials credentials = getCredentials(build);
-        FilePath secrets = secretsDir(workspace);
-        String dirName = UUID.randomUUID().toString();
-        final FilePath dir = secrets.child(dirName);
-        dir.mkdirs();
-        secrets.chmod(/*0700*/448);
+    @Override protected final FilePath write(FileCredentials credentials, FilePath dir) throws IOException, InterruptedException {
         FilePath secret = dir.child(credentials.getFileName());
-        copy(secret, credentials);
-        if (secret.isDirectory()) { /* ZipFileBinding */
-            // needs to be writable so we can delete its contents
-            // needs to be executable so we can list the contents
-            secret.chmod(0700);
-        } else {
-            secret.chmod(0400);
-        }
-        return new SingleEnvironment(secret.getRemote(), new UnbinderImpl(dirName));
+        secret.copyFrom(credentials.getContent());
+        secret.chmod(0400);
+        return secret;
     }
-    
+
+    @SuppressWarnings("unused")
+    @Deprecated
     private static class UnbinderImpl implements Unbinder {
-
         private static final long serialVersionUID = 1;
-
         private final String dirName;
-        
-        UnbinderImpl(String dirName) {
+
+        private UnbinderImpl(String dirName) {
             this.dirName = dirName;
         }
-        
-        @Override public void unbind(@Nonnull Run<?, ?> build,
-                                     FilePath workspace,
-                                     Launcher launcher,
-                                     @Nonnull TaskListener listener) throws IOException, InterruptedException {
-            secretsDir(workspace).child(dirName).deleteRecursive();
+
+        protected Object readResolve() {
+            return new AbstractOnDiskBinding.UnbinderImpl(dirName);
         }
-        
-    }
 
-    private static FilePath secretsDir(FilePath workspace) {
-        return tempDir(workspace).child("secretFiles");
-    }
-
-    // TODO 1.652 use WorkspaceList.tempDir
-    private static FilePath tempDir(FilePath ws) {
-        return ws.sibling(ws.getName() + System.getProperty(WorkspaceList.class.getName(), "@") + "tmp");
-    }
-
-    protected void copy(FilePath secret, FileCredentials credentials) throws IOException, InterruptedException {
-        secret.copyFrom(credentials.getContent());
+        @Override
+        public void unbind(@Nonnull Run<?, ?> build,
+                           FilePath workspace,
+                           Launcher launcher,
+                           @Nonnull TaskListener listener) throws IOException, InterruptedException {
+            // replaced by the AbstractOnDiskBinding.UnbinderImpl implementation
+        }
     }
 
     @Symbol("file")

--- a/src/main/java/org/jenkinsci/plugins/credentialsbinding/impl/UnbindableDir.java
+++ b/src/main/java/org/jenkinsci/plugins/credentialsbinding/impl/UnbindableDir.java
@@ -1,0 +1,88 @@
+package org.jenkinsci.plugins.credentialsbinding.impl;
+
+import java.io.IOException;
+import java.util.UUID;
+
+import javax.annotation.Nonnull;
+
+import org.jenkinsci.plugins.credentialsbinding.BindingDescriptor;
+import org.jenkinsci.plugins.credentialsbinding.MultiBinding.Unbinder;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+import hudson.FilePath;
+import hudson.Launcher;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import hudson.slaves.WorkspaceList;
+
+/**
+ * Convenience class for creating a secure temporary directory dedicated to writing credentials file(s), and getting a
+ * corresponding {@link Unbinder} instance.
+ */
+public class UnbindableDir {
+
+    private final FilePath dirPath;
+    private final Unbinder unbinder;
+
+    private UnbindableDir(FilePath dirPath) {
+        this.dirPath = dirPath;
+        this.unbinder = new UnbinderImpl(dirPath.getName());
+    }
+
+    public Unbinder getUnbinder() {
+        return unbinder;
+    }
+
+    public FilePath getDirPath() {
+        return dirPath;
+    }
+
+    /**
+     * Creates a new, secure, directory under a base workspace temporary directory. Also instantiates
+     * an {@link Unbinder} for deleting this directory later. This can only safely be used for binding
+     * implementations for which {@link BindingDescriptor#requiresWorkspace()} is true.
+     * @param workspace The workspace, can't be null (temporary dirs are created next to it)
+     * @return
+     * @throws IOException
+     * @throws InterruptedException
+     */
+    public static UnbindableDir create(@Nonnull FilePath workspace)
+            throws IOException, InterruptedException {
+        final FilePath secrets = secretsDir(workspace);
+        final String dirName = UUID.randomUUID().toString();
+        final FilePath dir = secrets.child(dirName);
+        dir.mkdirs();
+        secrets.chmod(0700);
+        dir.chmod(0700);
+        return new UnbindableDir(dir);
+    }
+
+    private static FilePath secretsDir(FilePath workspace) {
+        return tempDir(workspace).child("secretFiles");
+    }
+
+    // TODO 1.652 use WorkspaceList.tempDir
+    private static FilePath tempDir(FilePath ws) {
+        return ws.sibling(ws.getName() + System.getProperty(WorkspaceList.class.getName(), "@") + "tmp");
+    }
+
+    @Restricted(NoExternalUse.class)
+    protected static class UnbinderImpl implements Unbinder {
+        private static final long serialVersionUID = 1;
+        private final String dirName;
+
+        protected UnbinderImpl(String dirName) {
+            this.dirName = dirName;
+        }
+
+        @Override
+        public void unbind(@Nonnull Run<?, ?> build,
+                FilePath workspace,
+                Launcher launcher,
+                @Nonnull TaskListener listener) throws IOException, InterruptedException {
+            secretsDir(workspace).child(dirName).deleteRecursive();
+        }
+    }
+
+}

--- a/src/main/java/org/jenkinsci/plugins/credentialsbinding/impl/ZipFileBinding.java
+++ b/src/main/java/org/jenkinsci/plugins/credentialsbinding/impl/ZipFileBinding.java
@@ -44,14 +44,21 @@ import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
 
-public class ZipFileBinding extends FileBinding {
+public class ZipFileBinding extends AbstractOnDiskBinding<FileCredentials> {
 
     @DataBoundConstructor public ZipFileBinding(String variable, String credentialsId) {
         super(variable, credentialsId);
     }
 
-    @Override protected void copy(FilePath secret, FileCredentials credentials) throws IOException, InterruptedException {
+    @Override protected Class<FileCredentials> type() {
+        return FileCredentials.class;
+    }
+
+    @Override protected final FilePath write(FileCredentials credentials, FilePath dir) throws IOException, InterruptedException {
+        FilePath secret = dir.child(credentials.getFileName());
         secret.unzipFrom(credentials.getContent());
+        secret.chmod(0700); // note: it's a directory
+        return secret;
     }
 
     @Symbol("zip")


### PR DESCRIPTION
This PR is the successor of #25 (which was merged and then rolled-back, and thus can't be updated anymore). The goal is still to ease writing new credentials binding implementations which write to temp files without copy/pasting what exists already in FileBinder.

The code from #25 was reviewed already by @jglick, and it was fine, expect it was specific to writing Binding implementation, and was not supporting MultiBinding at all. Meaning it wasn't helping in cases like the SSH key binding proposed in #18 for instance.

This new PR includes two commits:

-	83ba9e2 are the changes already reviewed in PR #25, simply rebased on master
-	8c50bd3 is a refactoring to make some utility code also available to MultiBinding implementations. The AbstractOnDiskBinding API is unchanged (meaning jenkinsci/docker-commons-plugin#54 should still be ok), but the code for managing the temp dirwas moved to the new UnbindableDir utility class.

Here is an example of using this new API to simplify a MultiBinding implementation (the SSH keys one from #18): thomasgl-orange/credentials-binding-plugin@a4423f31ea53f11bacfd5c20b71b103e29644965
