### PR TITLE
Fix CertificateMultiBindingTest on mac

### DIFF
--- a/src/test/resources/org/jenkinsci/plugins/credentialsbinding/impl/CertificateMultiBindingTest/basicsPipeline-step1.sh
+++ b/src/test/resources/org/jenkinsci/plugins/credentialsbinding/impl/CertificateMultiBindingTest/basicsPipeline-step1.sh
@@ -2,16 +2,23 @@
 set -e -x
 
 # check existence and permissions for the keystore file
-echo "checking \$MY_KEYSTORE:" 
+echo "checking \$MY_KEYSTORE:"
 test -f "$MY_KEYSTORE"
-[ $(stat -c %a "$MY_KEYSTORE")               = 400 ]
-[ $(stat -c %a $(dirname "$MY_KEYSTORE"))    = 700 ]
-[ $(stat -c %a $(dirname "$MY_KEYSTORE")/..) = 700 ]
+
+if [ "$(uname)" = "Darwin" ]; then
+  [ $(stat -f %p "$MY_KEYSTORE")               = 100400 ]
+  [ $(stat -f %p $(dirname "$MY_KEYSTORE"))    = 40700 ]
+  [ $(stat -f %p $(dirname "$MY_KEYSTORE")/..) = 40700 ]
+else
+  [ $(stat -c %a "$MY_KEYSTORE")               = 400 ]
+  [ $(stat -c %a $(dirname "$MY_KEYSTORE"))    = 700 ]
+  [ $(stat -c %a $(dirname "$MY_KEYSTORE")/..) = 700 ]
+fi
 
 # check the other variables
-echo "checking \$KEYSTORE_PASSWORD:" 
+echo "checking \$KEYSTORE_PASSWORD:"
 [ ${#KEYSTORE_PASSWORD} = 7 ]
-echo "checking \$KEYSTORE_ALIAS:" 
+echo "checking \$KEYSTORE_ALIAS:"
 [ ${#KEYSTORE_ALIAS} = 15 ]
 
 # keep location of the keystore file for the next step


### PR DESCRIPTION
The `stat` CLI is appararently different on mac than it is on linux