### PR TITLE
[JENKINS-44860] Username in a UsernamePasswordMultiBinding should not be considered sensitive

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/credentialsbinding/MultiBinding.java
+++ b/src/main/java/org/jenkinsci/plugins/credentialsbinding/MultiBinding.java
@@ -80,19 +80,35 @@ public abstract class MultiBinding<C extends StandardCredentials> extends Abstra
     public static final class MultiEnvironment implements Serializable {
 
         private final Map<String,String> values;
+        private final Map<String,String> secretValues;
         private final Unbinder unbinder;
 
-        public MultiEnvironment(Map<String,String> values) {
-            this(values, new NullUnbinder());
+        public MultiEnvironment(Map<String,String> secretValues) {
+            this(secretValues, Collections.<String, String>emptyMap());
         }
 
-        public MultiEnvironment(Map<String,String> values, Unbinder unbinder) {
-            this.values = new HashMap<String,String>(values);
+        public MultiEnvironment(Map<String,String> secretValues, Map<String,String> publicValues) {
+            this(secretValues, publicValues, new NullUnbinder());
+        }
+
+        public MultiEnvironment(Map<String,String> secretValues, Unbinder unbinder) {
+            this(secretValues, Collections.<String, String>emptyMap(), unbinder);
+        }
+
+        public MultiEnvironment(Map<String,String> secretValues, Map<String,String> publicValues, Unbinder unbinder) {
+            this.secretValues = new HashMap<String,String>(secretValues);
+            this.values = new HashMap<String,String>();
+            this.values.putAll(secretValues);
+            this.values.putAll(publicValues);
             this.unbinder = unbinder;
         }
 
         public Map<String,String> getValues() {
             return Collections.unmodifiableMap(values);
+        }
+
+        public Map<String,String> getSecretValues() {
+            return Collections.unmodifiableMap(secretValues);
         }
 
         public Unbinder getUnbinder() {

--- a/src/main/java/org/jenkinsci/plugins/credentialsbinding/impl/BindingStep.java
+++ b/src/main/java/org/jenkinsci/plugins/credentialsbinding/impl/BindingStep.java
@@ -105,6 +105,7 @@ public final class BindingStep extends Step {
             Launcher launcher = getContext().get(Launcher.class);
 
             Map<String,String> overrides = new HashMap<String,String>();
+            Map<String,String> secretOverrides = new HashMap<String,String>();
             List<MultiBinding.Unbinder> unbinders = new ArrayList<MultiBinding.Unbinder>();
             for (MultiBinding<?> binding : step.bindings) {
                 if (binding.getDescriptor().requiresWorkspace() &&
@@ -114,10 +115,12 @@ public final class BindingStep extends Step {
                 MultiBinding.MultiEnvironment environment = binding.bind(run, workspace, launcher, listener);
                 unbinders.add(environment.getUnbinder());
                 overrides.putAll(environment.getValues());
+                secretOverrides.putAll(environment.getSecretValues());
             }
             getContext().newBodyInvoker().
                     withContext(EnvironmentExpander.merge(getContext().get(EnvironmentExpander.class), new Overrider(overrides))).
-                    withContext(BodyInvoker.mergeConsoleLogFilters(getContext().get(ConsoleLogFilter.class), new Filter(overrides.values(), run.getCharset().name()))).
+                    withContext(BodyInvoker.mergeConsoleLogFilters(getContext().get(ConsoleLogFilter.class),
+                            new Filter(secretOverrides.values(), run.getCharset().name()))).
                     withCallback(new Callback(unbinders)).
                     start();
             return false;

--- a/src/main/java/org/jenkinsci/plugins/credentialsbinding/impl/SecretBuildWrapper.java
+++ b/src/main/java/org/jenkinsci/plugins/credentialsbinding/impl/SecretBuildWrapper.java
@@ -95,7 +95,7 @@ public class SecretBuildWrapper extends BuildWrapper {
         for (MultiBinding binding : bindings) {
             MultiBinding.MultiEnvironment e = binding.bind(build, build.getWorkspace(), launcher, listener);
             m.add(e);
-            secrets.addAll(e.getValues().values());
+            secrets.addAll(e.getSecretValues().values());
         }
 
         if (!secrets.isEmpty()) {

--- a/src/main/java/org/jenkinsci/plugins/credentialsbinding/impl/UsernamePasswordMultiBinding.java
+++ b/src/main/java/org/jenkinsci/plugins/credentialsbinding/impl/UsernamePasswordMultiBinding.java
@@ -74,14 +74,15 @@ public class UsernamePasswordMultiBinding extends MultiBinding<StandardUsernameP
                                            @Nullable Launcher launcher,
                                            @Nonnull TaskListener listener) throws IOException, InterruptedException {
         StandardUsernamePasswordCredentials credentials = getCredentials(build);
-        Map<String,String> m = new HashMap<String,String>();
-        m.put(usernameVariable, credentials.getUsername());
-        m.put(passwordVariable, credentials.getPassword().getPlainText());
-        return new MultiEnvironment(m);
+        Map<String,String> secretValues = new HashMap<String,String>();
+        Map<String,String> publicValues = new HashMap<String,String>();
+        secretValues.put(passwordVariable, credentials.getPassword().getPlainText());
+        publicValues.put(usernameVariable, credentials.getUsername());
+        return new MultiEnvironment(secretValues, publicValues);
     }
 
     @Override public Set<String> variables() {
-        return new HashSet<String>(Arrays.asList(usernameVariable, passwordVariable));
+        return new HashSet<String>(Arrays.asList(passwordVariable));
     }
 
     @Symbol("usernamePassword")

--- a/src/test/java/org/jenkinsci/plugins/credentialsbinding/impl/UsernamePasswordMultiBindingTest.java
+++ b/src/test/java/org/jenkinsci/plugins/credentialsbinding/impl/UsernamePasswordMultiBindingTest.java
@@ -77,7 +77,7 @@ public class UsernamePasswordMultiBindingTest {
         FreeStyleBuild b = r.buildAndAssertSuccess(p);
         r.assertLogNotContains(password, b);
         assertEquals(username + '/' + password, b.getWorkspace().child("auth.txt").readToString().trim());
-        assertEquals("[pass, userid]", new TreeSet<String>(b.getSensitiveBuildVariables()).toString());
+        assertEquals("[pass]", new TreeSet<String>(b.getSensitiveBuildVariables()).toString());
     }
 
 }


### PR DESCRIPTION
We have credentials such as slack usernames and passwords. The usernames would match commonly occurring strings in the console output, and there'd be '****' everywhere, even though it's not sensitive information.

This attempts to fix that. If there is an argument that usernames are sensitive in some cases, perhaps this should go a bit further and add a checkbox to mark that the username is sensitive.