### PR TITLE
Avoid NPE when usernamevar not specified

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/credentialsbinding/impl/UsernamePasswordMultiBinding.java
+++ b/src/main/java/org/jenkinsci/plugins/credentialsbinding/impl/UsernamePasswordMultiBinding.java
@@ -37,6 +37,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+
 import org.jenkinsci.Symbol;
 
 import org.jenkinsci.plugins.credentialsbinding.BindingDescriptor;
@@ -75,7 +76,9 @@ public class UsernamePasswordMultiBinding extends MultiBinding<StandardUsernameP
                                            @Nonnull TaskListener listener) throws IOException, InterruptedException {
         StandardUsernamePasswordCredentials credentials = getCredentials(build);
         Map<String,String> m = new HashMap<String,String>();
-        m.put(usernameVariable, credentials.getUsername());
+        if(usernameVariable != null && usernameVariable.length() != 0) {
+            m.put(usernameVariable, credentials.getUsername());
+        }
         m.put(passwordVariable, credentials.getPassword().getPlainText());
         return new MultiEnvironment(m);
     }


### PR DESCRIPTION
When using Jenkinsfiles, you can use the multibinding while avoiding to
specify either username or password. Seeing that you probably would
wan't the password in all cases, special treatment of the username has
been added.

This commit doesn't add testing, since I can't seem to reproduce the
problem in the testing instance.

Any recommendations on this are very welcome :-)