### PR TITLE
[JENKINS-49535] Improve error message when credentials entry is not found

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/credentialsbinding/MultiBinding.java
+++ b/src/main/java/org/jenkinsci/plugins/credentialsbinding/MultiBinding.java
@@ -150,7 +150,7 @@ public abstract class MultiBinding<C extends StandardCredentials> extends Abstra
     protected final @Nonnull C getCredentials(@Nonnull Run<?,?> build) throws IOException {
         IdCredentials cred = CredentialsProvider.findCredentialById(credentialsId, IdCredentials.class, build);
         if (cred==null)
-            throw new CredentialNotFoundException(credentialsId);
+            throw new CredentialNotFoundException("Could not find credentials entry with ID '" + credentialsId + "'");
 
         if (type().isInstance(cred)) {
             CredentialsProvider.track(build, cred);


### PR DESCRIPTION
Jenkins Blue Ocean only shows the exception message if something goes wrong. The stacktrace is only available if users explicitly switch back to the "old" log viewer. Therefore, only providing the credentials ID as CredentialNotFoundException message, makes it hard for Blue Ocean users to get a grasp of the problem.