### PR TITLE
Suppress stack trace from CredentialNotFoundException

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/credentialsbinding/impl/CredentialNotFoundException.java
+++ b/src/main/java/org/jenkinsci/plugins/credentialsbinding/impl/CredentialNotFoundException.java
@@ -1,20 +1,9 @@
 package org.jenkinsci.plugins.credentialsbinding.impl;
 
-import java.io.IOException;
+import hudson.AbortException;
 
-/**
- * @author Kohsuke Kawaguchi
- */
-public class CredentialNotFoundException extends IOException {
+public class CredentialNotFoundException extends AbortException {
     public CredentialNotFoundException(String message) {
         super(message);
-    }
-
-    public CredentialNotFoundException(String message, Throwable cause) {
-        super(message, cause);
-    }
-
-    public CredentialNotFoundException(Throwable cause) {
-        super(cause);
     }
 }

--- a/src/test/java/org/jenkinsci/plugins/credentialsbinding/impl/BindingStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/credentialsbinding/impl/BindingStepTest.java
@@ -244,9 +244,9 @@ public class BindingStepTest {
 
                 // make sure error message contains information about the actual type and the expected type
                 story.j.assertLogNotContains("s3cr3t", r);
-                story.j.assertLogContains(CredentialNotFoundException.class.getName(), r);
-                story.j.assertLogContains(StandardUsernamePasswordCredentials.class.getName(), r);
+                story.j.assertLogContains(StandardUsernamePasswordCredentials.class.getName(), r); // no descriptor for the interface type
                 story.j.assertLogContains(stringCredentialsDescriptor.getDisplayName(), r);
+                story.j.assertLogNotContains("\tat ", r);
             }
         });
     }


### PR DESCRIPTION
Amends cb9191d0d201792477c196aa20d876e5eec33694 since we do not want to print a stack trace in the case of a simple user error (mistyped or otherwise missing `credentialsId`).

I was reluctant to just discard the special exception type, in case some scripts were `catch`ing it.

Saw in a build run by @Vlatombe.