### PR TITLE
Trying to avoid a test flake

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/credentialsbinding/impl/BindingStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/credentialsbinding/impl/BindingStepTest.java
@@ -219,8 +219,7 @@ public class BindingStepTest {
                         + "withCredentials([file(variable: 'targetFile', credentialsId: '" + credentialsId + "')]) {\n"
                         + "  echo 'We should fail before getting here'\n"
                         + "}", true));
-                WorkflowRun b = p.scheduleBuild2(0).waitForStart();
-                story.j.assertBuildStatus(Result.FAILURE, story.j.waitForCompletion(b));
+                WorkflowRun b = story.j.assertBuildStatus(Result.FAILURE, p.scheduleBuild2(0));
                 story.j.assertLogNotContains("We should fail before getting here", b);
                 story.j.assertLogContains("Required context class hudson.FilePath is missing", b);
                 story.j.assertLogContains("Perhaps you forgot to surround the code with a step that provides this, such as: node", b);


### PR DESCRIPTION
Noticed a flake on Windows in a build of #55 which I thought might have been due to a race condition in `waitForCompletion` vs. logs:

```
Expected: a string containing "Required context class hudson.FilePath is missing"
     but: was "Started
[Pipeline] withCredentials
[Pipeline] // withCredentials
[Pipeline] End of Pipeline
"
	at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:20)
	at org.junit.Assert.assertThat(Assert.java:956)
	at org.junit.Assert.assertThat(Assert.java:923)
	at org.jvnet.hudson.test.JenkinsRule.assertLogContains(JenkinsRule.java:1261)
	at org.jenkinsci.plugins.credentialsbinding.impl.BindingStepTest$6.evaluate(BindingStepTest.java:225)
```

Evidently the build failed as expected but at the time of the assertion lacked the expected failure text.