### PR TITLE
Java 11 readiness: build both on JDK8 and JDK11

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,1 @@
-buildPlugin()
+buildPlugin(configurations: buildPlugin.recommendedConfigurations())

--- a/pom.xml
+++ b/pom.xml
@@ -20,11 +20,11 @@
   <properties>
     <revision>1.19</revision>
     <changelist>-SNAPSHOT</changelist>
-    <jenkins.version>2.60.3</jenkins.version>
+    <jenkins.version>2.150.1</jenkins.version>
     <java.level>8</java.level>
     <workflow-cps-plugin.version>2.32</workflow-cps-plugin.version>
-    <workflow-step-api-plugin.version>2.18</workflow-step-api-plugin.version>
-    <workflow-support-plugin.version>2.14</workflow-support-plugin.version>
+    <workflow-step-api-plugin.version>2.19</workflow-step-api-plugin.version>
+    <workflow-support-plugin.version>3.2</workflow-support-plugin.version>
   </properties>
   <licenses>
     <license>
@@ -72,12 +72,12 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>structs</artifactId>
-      <version>1.7</version>
+      <version>1.17</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-api</artifactId>
-      <version>2.16</version>
+      <version>2.30</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -150,6 +150,12 @@
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>script-security</artifactId>
+      <version>1.57</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>authorize-project</artifactId>
       <version>1.1.0</version>
       <scope>test</scope>
@@ -157,7 +163,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>scm-api</artifactId>
-      <version>2.0.8</version>
+      <version>2.2.6</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.37</version>
+    <version>3.42</version>
     <relativePath />
   </parent>
 


### PR DESCRIPTION
Making sure this plugin is constantly checked both building with JDK8 and JDK11.

This goes with the Jenkins Java 11 General Availability announcement made back in March, and we're making a pass to check plugins are looking good on a JDK11.

([to understand the Jenkinsfile content](https://wiki.jenkins.io/display/JENKINS/Java+11+Developer+Guidelines#Java11DeveloperGuidelines-MakesureyourpluginistestedinContinuousIntegrationonJava8andJava11atthesametime))

@jenkinsci/java11-support 