### PR TITLE
Update credentials plugin from 2.1.7 to 2.1.19 (2.2.0) CVE-2019-10320

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>credentials</artifactId>
-      <version>2.1.7</version>
+      <version>2.1.19</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
https://nvd.nist.gov/vuln/detail/CVE-2019-10320

https://wiki.jenkins.io/display/JENKINS/Credentials+Plugin
https://plugins.jenkins.io/credentials
https://github.com/jenkinsci/credentials-plugin/releases