### PR TITLE
Add support for Almquist shell in masking

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/credentialsbinding/masking/AlmquistShellSecretPatternFactory.java
+++ b/src/main/java/org/jenkinsci/plugins/credentialsbinding/masking/AlmquistShellSecretPatternFactory.java
@@ -1,0 +1,73 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2019 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.credentialsbinding.masking;
+
+import hudson.Extension;
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
+
+import javax.annotation.Nonnull;
+import java.util.Collection;
+import java.util.Collections;
+
+/**
+ * Almquist shell, aka ash, is the default shell in Alpine distribution
+ */
+@Extension
+@Restricted(NoExternalUse.class)
+public class AlmquistShellSecretPatternFactory implements SecretPatternFactory {
+
+    private static final char SINGLE_QUOTE = '\'';
+    private static final String START_FRAGMENT = "'\"";
+    private static final String END_FRAGMENT = "\"'";
+
+    private @Nonnull String getQuotedForm(@Nonnull String input) {
+        StringBuilder sb = new StringBuilder(input.length());
+        for (int i = 0; i < input.length(); i++) {
+            char c = input.charAt(i);
+            if (c == SINGLE_QUOTE) {
+                // a single quote is replaced by '"'"' which is the concatenation of
+                // '[part before...]' + "'" + '[...part after]'
+                // if there are multiple single quotes successively, they are included in the double quotes together
+                sb.append(START_FRAGMENT);
+                // the first one, at index i
+                sb.append(SINGLE_QUOTE);
+                for (int j = i + 1; j < input.length() && input.charAt(j) == SINGLE_QUOTE; j++) {
+                    sb.append(SINGLE_QUOTE);
+                    i++;
+                }
+                sb.append(END_FRAGMENT);
+            } else {
+                sb.append(c);
+            }
+        }
+        return sb.toString();
+    }
+
+    @Override
+    public @Nonnull Collection<String> getEncodedForms(@Nonnull String input) {
+        return Collections.singleton(getQuotedForm(input));
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/credentialsbinding/masking/AlmquistShellSecretPatternFactory.java
+++ b/src/main/java/org/jenkinsci/plugins/credentialsbinding/masking/AlmquistShellSecretPatternFactory.java
@@ -33,7 +33,7 @@ import java.util.Collection;
 import java.util.Collections;
 
 /**
- * Almquist shell, aka ash, is the default shell in Alpine distribution
+ * Almquist shell, aka ash, is the default shell in Alpine distribution.
  */
 @Extension
 @Restricted(NoExternalUse.class)

--- a/src/main/resources/org/jenkinsci/plugins/credentialsbinding/impl/BindingStep/help.html
+++ b/src/main/resources/org/jenkinsci/plugins/credentialsbinding/impl/BindingStep/help.html
@@ -74,7 +74,7 @@ foo'bar
 </code></pre>
 <p>
     Mangled secrets can only be detected on a best-effort basis. By default, Jenkins will attempt to mask mangled
-    secrets as they would appear in output of Bash and Windows batch. Without these strategies in place, mangled secrets
+    secrets as they would appear in output of Bourne shell, Bash, Almquist shell and Windows batch. Without these strategies in place, mangled secrets
     would appear in plain text in log files. In the example above, this would result in:
 </p>
 <pre><code>+ echo 'foo'\''bar'

--- a/src/test/java/org/jenkinsci/plugins/credentialsbinding/masking/AlmquistShellSecretPatternFactoryTest.java
+++ b/src/test/java/org/jenkinsci/plugins/credentialsbinding/masking/AlmquistShellSecretPatternFactoryTest.java
@@ -134,7 +134,7 @@ public class AlmquistShellSecretPatternFactoryTest {
     }
 
     private WorkflowRun runProject() throws Exception {
-        return j.assertBuildStatusSuccess(project.scheduleBuild2(0));
+        return j.buildAndAssertSuccess(project);
     }
 
 }

--- a/src/test/java/org/jenkinsci/plugins/credentialsbinding/masking/AlmquistShellSecretPatternFactoryTest.java
+++ b/src/test/java/org/jenkinsci/plugins/credentialsbinding/masking/AlmquistShellSecretPatternFactoryTest.java
@@ -95,7 +95,7 @@ public class AlmquistShellSecretPatternFactoryTest {
     private String credentialsId;
 
     @BeforeClass
-    public static void assumeBash() {
+    public static void assumeAsh() {
         // ash = Almquist shell, default one used in Alpine
         assumeThat("ash", is(executable()));
         // due to https://github.com/jenkinsci/durable-task-plugin/blob/e75123eda986f20a390d92cc892c3d206e60aefb/src/main/java/org/jenkinsci/plugins/durabletask/BourneShellScript.java#L149

--- a/src/test/java/org/jenkinsci/plugins/credentialsbinding/masking/AlmquistShellSecretPatternFactoryTest.java
+++ b/src/test/java/org/jenkinsci/plugins/credentialsbinding/masking/AlmquistShellSecretPatternFactoryTest.java
@@ -56,17 +56,20 @@ import static org.junit.Assume.assumeThat;
 public class AlmquistShellSecretPatternFactoryTest {
 
     // ' is escaped as '"'"', '' as '"''"', ''' as '"'''"'
-    public static final @DataPoint String MULTIPLE_QUOTES = "ab'cd''ef'''gh"; //2
+    public static final @DataPoint String MULTIPLE_QUOTES = "ab'cd''ef'''gh";
     // "starting" and "ending" single quotes are escaped as "middle" single quotes
-    public static final @DataPoint String SURROUNDED_BY_QUOTES = "'abc'"; //3
-    public static final @DataPoint String SURROUNDED_BY_QUOTES_AND_MIDDLE = "'ab'cd'"; //4
-    public static final @DataPoint String OTHER_SIMPLE1 = "abc"; //5
-    public static final @DataPoint String OTHER_SIMPLE2 = "ab'cd"; //6
-    public static final @DataPoint String OTHER_SIMPLE3 = "ab''cd"; //7
-    public static final @DataPoint String OTHER_SIMPLE4 = "ab'c'd"; //8
+    public static final @DataPoint String SURROUNDED_BY_QUOTES = "'abc'";
+    public static final @DataPoint String SURROUNDED_BY_QUOTES_AND_MIDDLE = "'ab'cd'";
+    public static final @DataPoint String SIMPLE_CASE_1 = "abc";
+    public static final @DataPoint String SIMPLE_CASE_2 = "ab'cd";
+    public static final @DataPoint String SIMPLE_CASE_3 = "ab''cd";
+    public static final @DataPoint String SIMPLE_CASE_4 = "ab'c'd";
+    public static final @DataPoint String LEADING_QUOTE = "'a\"b\"c d";
+    public static final @DataPoint String TRAILING_QUOTE = "a\"b\"c d'";
     public static final @DataPoint String SAMPLE_PASSWORD = "}#T14'GAz&H!{$U_";
     public static final @DataPoint String ANOTHER_SAMPLE_PASSWORD = "a'b\"c\\d(e)#";
     public static final @DataPoint String ONE_MORE = "'\"'(foo)'\"'";
+    public static final @DataPoint String FULL_ASCII = "!\"#$%&'()*+,-./ 0123456789:;<=>? @ABCDEFGHIJKLMNO PQRSTUVWXYZ[\\]^_ `abcdefghijklmno pqrstuvwxyz{|}~";
 
     @DataPoints
     public static List<String> generatePasswords() {
@@ -111,6 +114,7 @@ public class AlmquistShellSecretPatternFactoryTest {
                         "  withCredentials([string(credentialsId: '" + credentialsId + "', variable: 'CREDENTIALS')]) {\n" +
                         "    sh '''\n" +
                         "       echo begin0 $CREDENTIALS end0\n" +
+                        // begin2 => 2 for double quotes
                         "       echo \"begin2 $CREDENTIALS end2\"\n" +
                         "    '''\n" +
                         "  }\n" +

--- a/src/test/java/org/jenkinsci/plugins/credentialsbinding/masking/AlmquistShellSecretPatternFactoryTest.java
+++ b/src/test/java/org/jenkinsci/plugins/credentialsbinding/masking/AlmquistShellSecretPatternFactoryTest.java
@@ -1,0 +1,136 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2019 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.jenkinsci.plugins.credentialsbinding.masking;
+
+import hudson.tasks.Shell;
+import org.jenkinsci.plugins.credentialsbinding.test.CredentialsTestUtil;
+import org.jenkinsci.plugins.credentialsbinding.test.Executables;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.experimental.theories.DataPoint;
+import org.junit.experimental.theories.DataPoints;
+import org.junit.experimental.theories.Theories;
+import org.junit.experimental.theories.Theory;
+import org.junit.runner.RunWith;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.UUID;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.startsWith;
+import static org.jenkinsci.plugins.credentialsbinding.test.Executables.executable;
+import static org.junit.Assume.assumeThat;
+
+@RunWith(Theories.class)
+public class AlmquistShellSecretPatternFactoryTest {
+
+    // ' is escaped as '"'"', '' as '"''"', ''' as '"'''"'
+    public static final @DataPoint String MULTIPLE_QUOTES = "ab'cd''ef'''gh"; //2
+    // "starting" and "ending" single quotes are escaped as "middle" single quotes
+    public static final @DataPoint String SURROUNDED_BY_QUOTES = "'abc'"; //3
+    public static final @DataPoint String SURROUNDED_BY_QUOTES_AND_MIDDLE = "'ab'cd'"; //4
+    public static final @DataPoint String OTHER_SIMPLE1 = "abc"; //5
+    public static final @DataPoint String OTHER_SIMPLE2 = "ab'cd"; //6
+    public static final @DataPoint String OTHER_SIMPLE3 = "ab''cd"; //7
+    public static final @DataPoint String OTHER_SIMPLE4 = "ab'c'd"; //8
+    public static final @DataPoint String SAMPLE_PASSWORD = "}#T14'GAz&H!{$U_";
+    public static final @DataPoint String ANOTHER_SAMPLE_PASSWORD = "a'b\"c\\d(e)#";
+    public static final @DataPoint String ONE_MORE = "'\"'(foo)'\"'";
+
+    @DataPoints
+    public static List<String> generatePasswords() {
+        Random random = new Random(100);
+        List<String> passwords = new ArrayList<>(10);
+        for (int i = 0; i < 10; i++) {
+            int length = random.nextInt(24) + 8;
+            StringBuilder sb = new StringBuilder(length);
+            for (int j = 0; j < length; j++) {
+                // choose a (printable) character in the closed range [' ', '~']
+                // 0x7f is DEL, 0x7e is ~, and space is the first printable ASCII character
+                char next = (char) (' ' + random.nextInt('\u007f' - ' '));
+                sb.append(next);
+            }
+            passwords.add(sb.toString());
+        }
+        return passwords;
+    }
+
+    @ClassRule public static JenkinsRule j = new JenkinsRule();
+
+    private WorkflowJob project;
+    private String credentialsId;
+
+    @BeforeClass
+    public static void assumeBash() {
+        // ash = Almquist shell, default one used in Alpine
+        assumeThat("ash", is(executable()));
+        // due to https://github.com/jenkinsci/durable-task-plugin/blob/e75123eda986f20a390d92cc892c3d206e60aefb/src/main/java/org/jenkinsci/plugins/durabletask/BourneShellScript.java#L149
+        // on Windows
+        assumeThat("nohup", is(executable()));
+    }
+
+    @Before
+    public void setUp() throws IOException {
+        j.jenkins.getDescriptorByType(Shell.DescriptorImpl.class).setShell(Executables.getPathToExecutable("ash"));
+        project = j.createProject(WorkflowJob.class);
+        credentialsId = UUID.randomUUID().toString();
+
+        project.setDefinition(new CpsFlowDefinition(
+                "node {\n" +
+                        "  withCredentials([string(credentialsId: '" + credentialsId + "', variable: 'CREDENTIALS')]) {\n" +
+                        "    sh '''\n" +
+                        "       echo begin0 $CREDENTIALS end0\n" +
+                        "       echo \"begin2 $CREDENTIALS end2\"\n" +
+                        "    '''\n" +
+                        "  }\n" +
+                        "}", true));
+    }
+
+    @Theory
+    public void credentialsAreMaskedInLogs(String credentials) throws Exception {
+        assumeThat(credentials, not(startsWith("****")));
+
+        CredentialsTestUtil.setStringCredentials(j.jenkins, credentialsId, credentials);
+        WorkflowRun run = runProject();
+
+        j.assertLogContains("begin0 **** end0", run);
+        j.assertLogContains("begin2 **** end2", run);
+        j.assertLogNotContains(credentials, run);
+    }
+
+    private WorkflowRun runProject() throws Exception {
+        return j.assertBuildStatusSuccess(project.scheduleBuild2(0));
+    }
+
+}


### PR DESCRIPTION
Almquist shell is the default one for Alpine. The escape schema is a bit special compared to the other.

```
pwd="pass'word"
set -x
echo $pwd
```
outputs
`+ echo 'pass'"'"'word'`

You can reproduce those commands on `jenkinsci/jnlp-slave:alpine` default shell.

Unit tests added.

For the review information: `'` is escaped as `'"'"'`, `''` as `'"''"'`, `'''` as `'"'''"'`

@jvz 