### PR TITLE
Do not mask secrets shorter than (3) characters.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/credentialsbinding/masking/SecretPatterns.java
+++ b/src/main/java/org/jenkinsci/plugins/credentialsbinding/masking/SecretPatterns.java
@@ -36,7 +36,7 @@ import java.util.stream.Collectors;
 @Restricted(NoExternalUse.class)
 public class SecretPatterns {
 
-    private static final int MINIMUM_PASSWORD_MASKING_LENGTH = 3;
+    private static final int MINIMUM_SECRET_MASKING_LENGTH = 3;
 
     private static final Comparator<String> BY_LENGTH_DESCENDING =
             Comparator.comparingInt(String::length).reversed().thenComparing(String::compareTo);
@@ -53,7 +53,7 @@ public class SecretPatterns {
     public static @Nonnull Pattern getAggregateSecretPattern(@Nonnull Collection<String> inputs) {
         String pattern = inputs.stream()
                 .filter(input -> !input.isEmpty())
-                .filter(input -> input.length() > MINIMUM_PASSWORD_MASKING_LENGTH)
+                .filter(input -> input.length() > MINIMUM_SECRET_MASKING_LENGTH)
                 .flatMap(input ->
                         SecretPatternFactory.all().stream().flatMap(factory ->
                                 factory.getEncodedForms(input).stream()))

--- a/src/main/java/org/jenkinsci/plugins/credentialsbinding/masking/SecretPatterns.java
+++ b/src/main/java/org/jenkinsci/plugins/credentialsbinding/masking/SecretPatterns.java
@@ -52,7 +52,6 @@ public class SecretPatterns {
      */
     public static @Nonnull Pattern getAggregateSecretPattern(@Nonnull Collection<String> inputs) {
         String pattern = inputs.stream()
-                .filter(input -> !input.isEmpty())
                 .filter(input -> input.length() > MINIMUM_SECRET_MASKING_LENGTH)
                 .flatMap(input ->
                         SecretPatternFactory.all().stream().flatMap(factory ->

--- a/src/main/java/org/jenkinsci/plugins/credentialsbinding/masking/SecretPatterns.java
+++ b/src/main/java/org/jenkinsci/plugins/credentialsbinding/masking/SecretPatterns.java
@@ -36,6 +36,8 @@ import java.util.stream.Collectors;
 @Restricted(NoExternalUse.class)
 public class SecretPatterns {
 
+    private static final int MINIMUM_PASSWORD_MASKING_LENGTH = 3;
+
     private static final Comparator<String> BY_LENGTH_DESCENDING =
             Comparator.comparingInt(String::length).reversed().thenComparing(String::compareTo);
 
@@ -51,6 +53,7 @@ public class SecretPatterns {
     public static @Nonnull Pattern getAggregateSecretPattern(@Nonnull Collection<String> inputs) {
         String pattern = inputs.stream()
                 .filter(input -> !input.isEmpty())
+                .filter(input -> input.length() > MINIMUM_PASSWORD_MASKING_LENGTH)
                 .flatMap(input ->
                         SecretPatternFactory.all().stream().flatMap(factory ->
                                 factory.getEncodedForms(input).stream()))


### PR DESCRIPTION
Only mask secrets greater than a minimum number of characters. Masking really short secrets can play havoc with the log. For example, if the password value is "a", all instances of 'a' in the log will be replaced by the masking string. This makes the log unreadable.

The `MINIMUM_SECRET_MASKING_LENGTH` is arbitrary, but 3 seems like a good compromise to not mask too many things that shouldn't be while still masking meaningful secrets. It could be 2. Or 4. Making it user configurable is a bit excessive.

@jvz @Wadeck @daniel-beck 