### PR TITLE
Demonstrate adding findsecbugs to spotbugs.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -145,4 +145,22 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>com.github.spotbugs</groupId>
+        <artifactId>spotbugs-maven-plugin</artifactId>
+        <configuration>
+          <plugins>
+            <plugin>
+              <groupId>com.h3xstream.findsecbugs</groupId>
+              <artifactId>findsecbugs-plugin</artifactId>
+              <version>1.10.1</version>
+            </plugin>
+          </plugins>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
 </project>


### PR DESCRIPTION
Demonstrate adding findsecbugs to spotbugs. This commit is a demonstration and is not intended to be merged as-is.

Similar to jenkinsci/platformlabeler-plugin#165, findsecbugs finds no issues in this plugin. Nothing will need to be done here when the parent pom is updated to include findsecbugs.

---

My plan is to add findsecbugs at the plugin pom after sufficient testing and communication. 