### PR TITLE
Add some documentation about not masking multi-line secrets.

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/credentialsbinding/Binding/help-variable.html
+++ b/src/main/resources/org/jenkinsci/plugins/credentialsbinding/Binding/help-variable.html
@@ -1,3 +1,3 @@
 <div>
-    Name of an environment variable to be set during the build.
+    Name of an environment variable to be set during the build. The contents of this location are not masked.
 </div>

--- a/src/main/resources/org/jenkinsci/plugins/credentialsbinding/impl/BindingStep/config.properties
+++ b/src/main/resources/org/jenkinsci/plugins/credentialsbinding/impl/BindingStep/config.properties
@@ -1,3 +1,4 @@
 blurb=\
     Secret values are masked on a best-effort basis to prevent <em>accidental</em> disclosure. \
+    Multiline secrets, such as the contents of a SSH private key file, are not masked. \
     See the inline help for details and usage guidelines.

--- a/src/main/resources/org/jenkinsci/plugins/credentialsbinding/impl/CertificateMultiBinding/help-keystoreVariable.html
+++ b/src/main/resources/org/jenkinsci/plugins/credentialsbinding/impl/CertificateMultiBinding/help-keystoreVariable.html
@@ -1,3 +1,3 @@
 <div>
-    Name of an environment variable to be set to the temporary keystore location during the build.
+    Name of an environment variable to be set to the temporary keystore location during the build. The contents of this file are not masked.
 </div>

--- a/src/main/resources/org/jenkinsci/plugins/credentialsbinding/impl/SSHUserPrivateKeyBinding/help-keyFileVariable.html
+++ b/src/main/resources/org/jenkinsci/plugins/credentialsbinding/impl/SSHUserPrivateKeyBinding/help-keyFileVariable.html
@@ -1,3 +1,3 @@
 <div>
-    Name of an environment variable to be set to the temporary path of the SSH key file during the build.
+    Name of an environment variable to be set to the temporary path of the SSH key file during the build. The contents of this file are not masked.
 </div>


### PR DESCRIPTION
There has been some uncertainty or confusion about whether multi-line secrets are expected to be masked. These types of secrets include things like SSH private key and various types of certificates. This PR adds a sentence in a few places to clarify that multi-line secrets are not masked.