### PR TITLE
2.164.x

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,1 @@
-buildPlugin(useAci: true, configurations: buildPlugin.recommendedConfigurations())
+buildPlugin(useAci: true)

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
   <properties>
     <revision>1.22</revision>
     <changelist>-SNAPSHOT</changelist>
-    <jenkins.version>2.150.3</jenkins.version>
+    <jenkins.version>2.164.3</jenkins.version>
     <java.level>8</java.level>
   </properties>
   <licenses>
@@ -54,8 +54,8 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.150.x</artifactId>
-        <version>7</version>
+        <artifactId>bom-2.164.x</artifactId>
+        <version>9</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>


### PR DESCRIPTION
As of https://github.com/jenkinsci/bom/pull/222 the BOM no longer supports 2.150.x, which was obsoleted 13 months ago with the [release of 2.164.x](https://jenkins.io/changelog-stable/#v2.164.1); the update center only promises to support the last five lines.