### PR TITLE
Replace 'slave' with 'agent' in README and help text

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ confidential files or strings which you want to be used by a job but
 which should not be kept in its SCM, or even visible from its
 config.xml. Saving these files on the server and referring to them by
 absolute path requires you to have a server login, and does not work on
-slaves. This plugin gives you an easy way to package up all a job’s
+agents. This plugin gives you an easy way to package up all a job’s
 secret files and passwords and access them using a single environment
 variable during the build.
 

--- a/src/main/resources/org/jenkinsci/plugins/credentialsbinding/impl/CertificateMultiBinding/help.html
+++ b/src/main/resources/org/jenkinsci/plugins/credentialsbinding/impl/CertificateMultiBinding/help.html
@@ -2,7 +2,7 @@
     Sets one variable to the username and one variable to the password given in the credentials.
 </div>
 <div>
-    <strong>Warning</strong>: if the master or slave node has multiple executors,
+    <strong>Warning</strong>: if the master or agent node has multiple executors,
     any other build running concurrently on the same node will be able to read
     the text of the secret, for example on Linux using <code>ps e</code>.
 </div>

--- a/src/main/resources/org/jenkinsci/plugins/credentialsbinding/impl/FileBinding/help.html
+++ b/src/main/resources/org/jenkinsci/plugins/credentialsbinding/impl/FileBinding/help.html
@@ -3,7 +3,7 @@
     (The file is deleted when the build completes.)
 </div>
 <div>
-    <strong>Warning</strong>: if the master or slave node has multiple executors,
+    <strong>Warning</strong>: if the master or agent node has multiple executors,
     any other build running concurrently on the same node will be able to read
     the contents of this file.
 </div>

--- a/src/main/resources/org/jenkinsci/plugins/credentialsbinding/impl/SSHUserPrivateKeyBinding/help.html
+++ b/src/main/resources/org/jenkinsci/plugins/credentialsbinding/impl/SSHUserPrivateKeyBinding/help.html
@@ -3,7 +3,7 @@
     (The file is deleted when the build completes.) Also optionally sets variables for the SSH key's username and passphrase.
 </div>
 <div>
-    <strong>Warning</strong>: if the master or slave node has multiple executors,
+    <strong>Warning</strong>: if the master or agent node has multiple executors,
     any other build running concurrently on the same node will be able to read
     the contents of this file.
 </div>

--- a/src/main/resources/org/jenkinsci/plugins/credentialsbinding/impl/StringBinding/help.html
+++ b/src/main/resources/org/jenkinsci/plugins/credentialsbinding/impl/StringBinding/help.html
@@ -2,7 +2,7 @@
     Sets a variable to the text given in the credentials.
 </div>
 <div>
-    <strong>Warning</strong>: if the master or slave node has multiple executors,
+    <strong>Warning</strong>: if the master or agent node has multiple executors,
     any other build running concurrently on the same node will be able to read
     the text of the secret, for example on Linux using <code>ps e</code>.
 </div>

--- a/src/main/resources/org/jenkinsci/plugins/credentialsbinding/impl/UsernamePasswordBinding/help.html
+++ b/src/main/resources/org/jenkinsci/plugins/credentialsbinding/impl/UsernamePasswordBinding/help.html
@@ -2,7 +2,7 @@
     Sets a variable to the username and password given in the credentials, separated by a colon (<code>:</code>).
 </div>
 <div>
-    <strong>Warning</strong>: if the master or slave node has multiple executors,
+    <strong>Warning</strong>: if the master or agent node has multiple executors,
     any other build running concurrently on the same node will be able to read
     the text of the secret, for example on Linux using <code>ps e</code>.
 </div>

--- a/src/main/resources/org/jenkinsci/plugins/credentialsbinding/impl/UsernamePasswordMultiBinding/help.html
+++ b/src/main/resources/org/jenkinsci/plugins/credentialsbinding/impl/UsernamePasswordMultiBinding/help.html
@@ -2,7 +2,7 @@
     Sets one variable to the username and one variable to the password given in the credentials.
 </div>
 <div>
-    <strong>Warning</strong>: if the master or slave node has multiple executors,
+    <strong>Warning</strong>: if the master or agent node has multiple executors,
     any other build running concurrently on the same node will be able to read
     the text of the secret, for example on Linux using <code>ps e</code>.
 </div>

--- a/src/main/resources/org/jenkinsci/plugins/credentialsbinding/impl/ZipFileBinding/help.html
+++ b/src/main/resources/org/jenkinsci/plugins/credentialsbinding/impl/ZipFileBinding/help.html
@@ -3,7 +3,7 @@
     (The directory is deleted when the build completes.)
 </div>
 <div>
-    <strong>Warning</strong>: if the master or slave node has multiple executors,
+    <strong>Warning</strong>: if the master or agent node has multiple executors,
     any other build running concurrently on the same node will be able to read
     the contents of this directory.
 </div>


### PR DESCRIPTION
I was looking at https://plugins.jenkins.io/credentials-binding/ and noticed that the docs still use the term 'slave', so we should update them.