### PR TITLE
[JENKINS-63366] Apply credentials masking first

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,10 @@
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-step-api</artifactId>
     </dependency>
     <dependency>

--- a/src/main/java/org/jenkinsci/plugins/credentialsbinding/impl/BindingStep.java
+++ b/src/main/java/org/jenkinsci/plugins/credentialsbinding/impl/BindingStep.java
@@ -142,9 +142,14 @@ public final class BindingStep extends Step {
                     v -> unix ? "$" + v : "%" + v + "%"
                 ).collect(Collectors.joining(" or ")));
             }
+            ConsoleLogFilter updatedLogFilter = new Filter(overrides.values(), run.getCharset().name());
+            ConsoleLogFilter previousLogFilter = getContext().get(ConsoleLogFilter.class);
+            if (previousLogFilter != null) {
+                updatedLogFilter = BodyInvoker.mergeConsoleLogFilters(updatedLogFilter, previousLogFilter);
+            }
             getContext().newBodyInvoker().
                     withContext(EnvironmentExpander.merge(getContext().get(EnvironmentExpander.class), new Overrider(overrides))).
-                    withContext(BodyInvoker.mergeConsoleLogFilters(getContext().get(ConsoleLogFilter.class), new Filter(overrides.values(), run.getCharset().name()))).
+                    withContext(updatedLogFilter).
                     withCallback(new Callback2(unbinders)).
                     start();
         }

--- a/src/test/java/org/jenkinsci/plugins/credentialsbinding/masking/BatchSecretPatternFactoryTest.java
+++ b/src/test/java/org/jenkinsci/plugins/credentialsbinding/masking/BatchSecretPatternFactoryTest.java
@@ -30,7 +30,7 @@ import org.jenkinsci.plugins.credentialsbinding.test.CredentialsTestUtil;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
-import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
@@ -66,8 +66,8 @@ public class BatchSecretPatternFactoryTest {
     private String credentialPlainText;
     private String credentialId;
 
-    @Before
-    public void assumeWindowsForBatch() throws Exception {
+    @BeforeClass
+    public static void assumeWindowsForBatch() throws Exception {
         assumeTrue(Functions.isWindows());
     }
 


### PR DESCRIPTION
This rearranges the ordering of the configured log filters for a step by
applying the newly created filter as the first log filter instead of
last.

See [JENKINS-63366](https://issues.jenkins-ci.org/browse/JENKINS-63366).

@jglick @Wadeck @daniel-beck @jeffret-b 