### PR TITLE
Highlight importance of using single-quotes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,11 +45,11 @@ withCredentials([usernamePassword(credentialsId: 'amazon', usernameVariable: 'US
 
 #### Note
 
-You should use a single quote (') instead of a double quote (") whenever you can. 
+You should use a single quote (`'`) instead of a double quote (`"`) whenever you can. 
 This is particularly important in Pipelines where a statement may be interpreted by both the Pipeline engine and an external interpreter, such as a Unix shell (`sh`) or Windows Command (`bat`) or Powershell (`ps`). 
 This reduces complications with password masking and command processing. 
 The first step in the above example properly demonstrates this. 
-The next two steps use the basic Pipeline "echo" step. 
+The next two steps use the basic Pipeline `echo` step. 
 The first one references the Groovy variable and needs no quotes. 
 The second one needs to use double quotes, so that the interpolation is performed in Groovy.
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ withCredentials([usernamePassword(credentialsId: 'amazon', usernameVariable: 'US
 #### Note
 
 You should use a single quote (') instead of a double quote (") whenever you can. 
-This is particularly important in Pipelines where a statement may be interpreted by both the Pipeline engine and an external interpreter, such as a Unix shell or Windows Command or Powershell. 
+This is particularly important in Pipelines where a statement may be interpreted by both the Pipeline engine and an external interpreter, such as a Unix shell (`sh`) or Windows Command (`bat`) or Powershell (`ps`). 
 This reduces complications with password masking and command processing. 
 The first step in the above example properly demonstrates this. 
 The next two steps use the basic Pipeline "echo" step. 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,18 @@ withCredentials([usernamePassword(credentialsId: 'amazon', usernameVariable: 'US
 }
 ```
 
+#### Note
+
+You should use a single quote (') instead of a double quote (") whenever you can. 
+This is particularly important in Pipelines where a statement may be interpreted by both the Pipeline engine and an external interpreter, such as a Unix shell or Windows Command or Powershell. 
+This reduces complications with password masking and command processing. 
+The first step in the above example properly demonstrates this. 
+The next two steps use the basic Pipeline "echo" step. 
+The first one references the Groovy variable and needs no quotes. 
+The second one needs to use double quotes, so that the interpolation is performed in Groovy.
+
+For more information, see the Pipeline step reference for [Credentials Binding Plugin](https://www.jenkins.io/doc/pipeline/steps/credentials-binding/).
+
 ## Changelog
 
 See [GitHub Releases](https://github.com/jenkinsci/credentials-binding-plugin/releases) for new releases,

--- a/src/main/resources/org/jenkinsci/plugins/credentialsbinding/impl/BindingStep/help.html
+++ b/src/main/resources/org/jenkinsci/plugins/credentialsbinding/impl/BindingStep/help.html
@@ -120,8 +120,3 @@ foo'bar
     <a href="https://jenkins.io/blog/2019/02/21/credentials-masking/" target="_blank">Limitations of Credentials Masking</a>
     blog post for more background.
 </p>
-<h4>Note</h4>
-<p>
-    You should use a single quote (') instead of a double quote (") whenever you can. 
-    This reduces complications with password masking and command processing.
-</p>

--- a/src/main/resources/org/jenkinsci/plugins/credentialsbinding/impl/BindingStep/help.html
+++ b/src/main/resources/org/jenkinsci/plugins/credentialsbinding/impl/BindingStep/help.html
@@ -120,3 +120,8 @@ foo'bar
     <a href="https://jenkins.io/blog/2019/02/21/credentials-masking/" target="_blank">Limitations of Credentials Masking</a>
     blog post for more background.
 </p>
+<h4>Note</h4>
+<p>
+    You should use a single quote (') instead of a double quote (") whenever you can. 
+    This reduces complications with password masking and command processing.
+</p>


### PR DESCRIPTION
Increase the documented visibility of the recommendation to use single quotes whenever possible.