### PR TITLE
[JENKINS-65398] Terminology update

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/credentialsbinding/impl/CertificateMultiBinding/help.html
+++ b/src/main/resources/org/jenkinsci/plugins/credentialsbinding/impl/CertificateMultiBinding/help.html
@@ -2,7 +2,7 @@
     Sets one variable to the username and one variable to the password given in the credentials.
 </div>
 <div>
-    <strong>Warning</strong>: if the controller or agent node has multiple executors,
+    <strong>Warning</strong>: if the Jenkins controller or agent node has multiple executors,
     any other build running concurrently on the same node will be able to read
     the text of the secret, for example on Linux using <code>ps e</code>.
 </div>

--- a/src/main/resources/org/jenkinsci/plugins/credentialsbinding/impl/CertificateMultiBinding/help.html
+++ b/src/main/resources/org/jenkinsci/plugins/credentialsbinding/impl/CertificateMultiBinding/help.html
@@ -2,7 +2,7 @@
     Sets one variable to the username and one variable to the password given in the credentials.
 </div>
 <div>
-    <strong>Warning</strong>: if the master or agent node has multiple executors,
+    <strong>Warning</strong>: if the controller or agent node has multiple executors,
     any other build running concurrently on the same node will be able to read
     the text of the secret, for example on Linux using <code>ps e</code>.
 </div>

--- a/src/main/resources/org/jenkinsci/plugins/credentialsbinding/impl/FileBinding/help.html
+++ b/src/main/resources/org/jenkinsci/plugins/credentialsbinding/impl/FileBinding/help.html
@@ -3,7 +3,7 @@
     (The file is deleted when the build completes.)
 </div>
 <div>
-    <strong>Warning</strong>: if the master or agent node has multiple executors,
+    <strong>Warning</strong>: if the controller or agent node has multiple executors,
     any other build running concurrently on the same node will be able to read
     the contents of this file.
 </div>

--- a/src/main/resources/org/jenkinsci/plugins/credentialsbinding/impl/FileBinding/help.html
+++ b/src/main/resources/org/jenkinsci/plugins/credentialsbinding/impl/FileBinding/help.html
@@ -3,7 +3,7 @@
     (The file is deleted when the build completes.)
 </div>
 <div>
-    <strong>Warning</strong>: if the controller or agent node has multiple executors,
+    <strong>Warning</strong>: if the Jenkins controller or agent node has multiple executors,
     any other build running concurrently on the same node will be able to read
     the contents of this file.
 </div>

--- a/src/main/resources/org/jenkinsci/plugins/credentialsbinding/impl/SSHUserPrivateKeyBinding/help.html
+++ b/src/main/resources/org/jenkinsci/plugins/credentialsbinding/impl/SSHUserPrivateKeyBinding/help.html
@@ -3,7 +3,7 @@
     (The file is deleted when the build completes.) Also optionally sets variables for the SSH key's username and passphrase.
 </div>
 <div>
-    <strong>Warning</strong>: if the controller or agent node has multiple executors,
+    <strong>Warning</strong>: if the Jenkins controller or agent node has multiple executors,
     any other build running concurrently on the same node will be able to read
     the contents of this file.
 </div>

--- a/src/main/resources/org/jenkinsci/plugins/credentialsbinding/impl/SSHUserPrivateKeyBinding/help.html
+++ b/src/main/resources/org/jenkinsci/plugins/credentialsbinding/impl/SSHUserPrivateKeyBinding/help.html
@@ -3,7 +3,7 @@
     (The file is deleted when the build completes.) Also optionally sets variables for the SSH key's username and passphrase.
 </div>
 <div>
-    <strong>Warning</strong>: if the master or agent node has multiple executors,
+    <strong>Warning</strong>: if the controller or agent node has multiple executors,
     any other build running concurrently on the same node will be able to read
     the contents of this file.
 </div>

--- a/src/main/resources/org/jenkinsci/plugins/credentialsbinding/impl/StringBinding/help.html
+++ b/src/main/resources/org/jenkinsci/plugins/credentialsbinding/impl/StringBinding/help.html
@@ -2,7 +2,7 @@
     Sets a variable to the text given in the credentials.
 </div>
 <div>
-    <strong>Warning</strong>: if the master or agent node has multiple executors,
+    <strong>Warning</strong>: if the controller or agent node has multiple executors,
     any other build running concurrently on the same node will be able to read
     the text of the secret, for example on Linux using <code>ps e</code>.
 </div>

--- a/src/main/resources/org/jenkinsci/plugins/credentialsbinding/impl/StringBinding/help.html
+++ b/src/main/resources/org/jenkinsci/plugins/credentialsbinding/impl/StringBinding/help.html
@@ -2,7 +2,7 @@
     Sets a variable to the text given in the credentials.
 </div>
 <div>
-    <strong>Warning</strong>: if the controller or agent node has multiple executors,
+    <strong>Warning</strong>: if the Jenkins controller or agent node has multiple executors,
     any other build running concurrently on the same node will be able to read
     the text of the secret, for example on Linux using <code>ps e</code>.
 </div>

--- a/src/main/resources/org/jenkinsci/plugins/credentialsbinding/impl/UsernamePasswordBinding/help.html
+++ b/src/main/resources/org/jenkinsci/plugins/credentialsbinding/impl/UsernamePasswordBinding/help.html
@@ -2,7 +2,7 @@
     Sets a variable to the username and password given in the credentials, separated by a colon (<code>:</code>).
 </div>
 <div>
-    <strong>Warning</strong>: if the controller or agent node has multiple executors,
+    <strong>Warning</strong>: if the Jenkins controller or agent node has multiple executors,
     any other build running concurrently on the same node will be able to read
     the text of the secret, for example on Linux using <code>ps e</code>.
 </div>

--- a/src/main/resources/org/jenkinsci/plugins/credentialsbinding/impl/UsernamePasswordBinding/help.html
+++ b/src/main/resources/org/jenkinsci/plugins/credentialsbinding/impl/UsernamePasswordBinding/help.html
@@ -2,7 +2,7 @@
     Sets a variable to the username and password given in the credentials, separated by a colon (<code>:</code>).
 </div>
 <div>
-    <strong>Warning</strong>: if the master or agent node has multiple executors,
+    <strong>Warning</strong>: if the controller or agent node has multiple executors,
     any other build running concurrently on the same node will be able to read
     the text of the secret, for example on Linux using <code>ps e</code>.
 </div>

--- a/src/main/resources/org/jenkinsci/plugins/credentialsbinding/impl/UsernamePasswordMultiBinding/help.html
+++ b/src/main/resources/org/jenkinsci/plugins/credentialsbinding/impl/UsernamePasswordMultiBinding/help.html
@@ -2,7 +2,7 @@
     Sets one variable to the username and one variable to the password given in the credentials.
 </div>
 <div>
-    <strong>Warning</strong>: if the controller or agent node has multiple executors,
+    <strong>Warning</strong>: if the Jenkins controller or agent node has multiple executors,
     any other build running concurrently on the same node will be able to read
     the text of the secret, for example on Linux using <code>ps e</code>.
 </div>

--- a/src/main/resources/org/jenkinsci/plugins/credentialsbinding/impl/UsernamePasswordMultiBinding/help.html
+++ b/src/main/resources/org/jenkinsci/plugins/credentialsbinding/impl/UsernamePasswordMultiBinding/help.html
@@ -2,7 +2,7 @@
     Sets one variable to the username and one variable to the password given in the credentials.
 </div>
 <div>
-    <strong>Warning</strong>: if the master or agent node has multiple executors,
+    <strong>Warning</strong>: if the controller or agent node has multiple executors,
     any other build running concurrently on the same node will be able to read
     the text of the secret, for example on Linux using <code>ps e</code>.
 </div>

--- a/src/main/resources/org/jenkinsci/plugins/credentialsbinding/impl/ZipFileBinding/help.html
+++ b/src/main/resources/org/jenkinsci/plugins/credentialsbinding/impl/ZipFileBinding/help.html
@@ -3,7 +3,7 @@
     (The directory is deleted when the build completes.)
 </div>
 <div>
-    <strong>Warning</strong>: if the controller or agent node has multiple executors,
+    <strong>Warning</strong>: if the Jenkins controller or agent node has multiple executors,
     any other build running concurrently on the same node will be able to read
     the contents of this directory.
 </div>

--- a/src/main/resources/org/jenkinsci/plugins/credentialsbinding/impl/ZipFileBinding/help.html
+++ b/src/main/resources/org/jenkinsci/plugins/credentialsbinding/impl/ZipFileBinding/help.html
@@ -3,7 +3,7 @@
     (The directory is deleted when the build completes.)
 </div>
 <div>
-    <strong>Warning</strong>: if the master or agent node has multiple executors,
+    <strong>Warning</strong>: if the controller or agent node has multiple executors,
     any other build running concurrently on the same node will be able to read
     the contents of this directory.
 </div>


### PR DESCRIPTION
The changes introduce terminology updates to replace `master` by `controller` and remaining `slave` by `agent`.
This is lead by [JENKINS-65398](https://issues.jenkins.io/browse/JENKINS-65398).

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue