### PR TITLE
`maven-windows` agents seem broken

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,1 @@
-buildPlugin(useAci: true)
+buildPlugin(platforms: ['maven', 'windows'])


### PR DESCRIPTION
Like https://github.com/jenkinsci/file-parameters-plugin/pull/44. CC @olblak, @MarkEWaite, @timja, not sure who manages this sort of thing?
