### PR TITLE
Introduced `MaskingOutputStream` to DRY between Pipeline & freestyle

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/credentialsbinding/impl/BindingStep.java
+++ b/src/main/java/org/jenkinsci/plugins/credentialsbinding/impl/BindingStep.java
@@ -216,8 +216,8 @@ public final class BindingStep extends Step {
             return this;
         }
 
-        @Override public OutputStream decorateLogger(AbstractBuild _ignore, final OutputStream logger) throws IOException, InterruptedException {
-            return new SecretPatterns.MaskingOutputStream(logger, Pattern.compile(pattern.getPlainText()), charsetName);
+        @Override public OutputStream decorateLogger(AbstractBuild _ignore, OutputStream logger) throws IOException, InterruptedException {
+            return new SecretPatterns.MaskingOutputStream(logger, () -> Pattern.compile(pattern.getPlainText()), charsetName);
         }
 
     }

--- a/src/main/java/org/jenkinsci/plugins/credentialsbinding/impl/SecretBuildWrapper.java
+++ b/src/main/java/org/jenkinsci/plugins/credentialsbinding/impl/SecretBuildWrapper.java
@@ -139,8 +139,8 @@ public class SecretBuildWrapper extends BuildWrapper {
             this.charsetName = charsetName;
         }
 
-        @Override public OutputStream decorateLogger(final AbstractBuild build, final OutputStream logger) throws IOException, InterruptedException {
-            return new SecretPatterns.MaskingOutputStream(logger, getPatternForBuild(build), charsetName) {
+        @Override public OutputStream decorateLogger(AbstractBuild build, OutputStream logger) throws IOException, InterruptedException {
+            return new SecretPatterns.MaskingOutputStream(logger, () -> getPatternForBuild(build), charsetName) {
                 @Override public void close() throws IOException {
                     super.close();
                     secretsForBuild.remove(build);

--- a/src/main/java/org/jenkinsci/plugins/credentialsbinding/masking/SecretPatterns.java
+++ b/src/main/java/org/jenkinsci/plugins/credentialsbinding/masking/SecretPatterns.java
@@ -34,10 +34,7 @@ import java.util.Comparator;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
-import org.kohsuke.accmod.Restricted;
-import org.kohsuke.accmod.restrictions.NoExternalUse;
 
-@Restricted(NoExternalUse.class)
 public class SecretPatterns {
 
     private static final Comparator<String> BY_LENGTH_DESCENDING =
@@ -100,5 +97,7 @@ public class SecretPatterns {
         }
 
     }
+
+    private SecretPatterns() {}
 
 }


### PR DESCRIPTION
Also allows this new utility, and the existing `getAggregateSecretPattern`, to be consumed from other plugins: https://github.com/jenkinsci/credentials-binding-plugin/pull/59#discussion_r288735761