### PR TITLE
[JENKINS-64361] Make fix for JENKINS-44860 apply to Pipeline step arguments as well

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/credentialsbinding/impl/BindingStep.java
+++ b/src/main/java/org/jenkinsci/plugins/credentialsbinding/impl/BindingStep.java
@@ -183,7 +183,7 @@ public final class BindingStep extends Step {
             for (Map.Entry<String,String> override : overrides.entrySet()) {
                 this.overrides.put(override.getKey(), Secret.fromString(override.getValue()));
             }
-            this.secretKeys = new HashSet<String>(secretKeys);
+            this.secretKeys = new HashSet<>(secretKeys);
         }
 
         @Override public void expand(EnvVars env) throws IOException, InterruptedException {
@@ -198,7 +198,7 @@ public final class BindingStep extends Step {
 
         private Object readResolve() {
             if (secretKeys == null) {
-                secretKeys = overrides.keySet();
+                secretKeys = new HashSet<>(overrides.keySet());
             }
             return this;
         }


### PR DESCRIPTION
See [JENKINS-64631](https://issues.jenkins.io/browse/JENKINS-64631).

#131 fixed [JENKINS-44860](https://issues.jenkins.io/browse/JENKINS-44860) by allowing usernames to remain unmasked in build logs, but it did not update the method introduced in #105 that Pipeline uses to know what environment variables contain secrets, so usernames were still being masked in Pipeline step arguments regardless of the value of `UsernameCredentials.isUsernameSecret`. This PR is a minor extension to #131 to address that issue.

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
