### PR TITLE
Use WorkspaceList.tempDir

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/credentialsbinding/impl/UnbindableDir.java
+++ b/src/main/java/org/jenkinsci/plugins/credentialsbinding/impl/UnbindableDir.java
@@ -58,14 +58,14 @@ public class UnbindableDir {
         return new UnbindableDir(dir);
     }
 
-    private static FilePath secretsDir(FilePath workspace) {
-        return tempDir(workspace).child("secretFiles");
+    private static FilePath secretsDir(FilePath workspace) throws IOException {
+        final FilePath path = WorkspaceList.tempDir(workspace);
+        if (path == null) {
+            throw new IOException("Failed to create tempDir");
+        }
+        return path.child("secretFiles");
     }
 
-    // TODO 1.652 use WorkspaceList.tempDir
-    private static FilePath tempDir(FilePath ws) {
-        return ws.sibling(ws.getName() + System.getProperty(WorkspaceList.class.getName(), "@") + "tmp");
-    }
 
     @Restricted(NoExternalUse.class)
     protected static class UnbinderImpl implements Unbinder {

--- a/src/test/java/org/jenkinsci/plugins/credentialsbinding/impl/BindingStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/credentialsbinding/impl/BindingStepTest.java
@@ -293,17 +293,12 @@ public class BindingStepTest {
                 FilePath key = ws.child("key");
                 assertTrue(key.exists());
                 assertEquals(secret, key.readToString());
-                FilePath secretFiles = tempDir(ws).child("secretFiles");
+                FilePath secretFiles = WorkspaceList.tempDir(ws).child("secretFiles");
                 assertTrue(secretFiles.isDirectory());
                 assertEquals(Collections.emptyList(), secretFiles.list());
                 assertEquals(Collections.<String>emptySet(), grep(b.getRootDir(), secret));
             }
         });
-    }
-
-    // TODO 1.652 use WorkspaceList.tempDir
-    private static FilePath tempDir(FilePath ws) {
-        return ws.sibling(ws.getName() + System.getProperty(WorkspaceList.class.getName(), "@") + "tmp");
     }
 
     @Issue("JENKINS-27389")


### PR DESCRIPTION
Addresses two Todos. `WorkspaceList.tempDir()` is available with core v1.652 and can replace the handwritten code.

I've added a null-check since `tempDir()` may return `null` under some circumstances. However, suggestions are welcome here.

---------------------------------------------
<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
