### PR TITLE
Ignore temporary files in `BindingStepTest.grep`

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/credentialsbinding/impl/BindingStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/credentialsbinding/impl/BindingStepTest.java
@@ -44,8 +44,10 @@ import hudson.security.FullControlOnceLoggedInAuthorizationStrategy;
 import hudson.slaves.WorkspaceList;
 import hudson.util.Secret;
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.NoSuchFileException;
 import java.util.Collections;
 import java.util.Set;
 import java.util.TreeSet;
@@ -468,8 +470,14 @@ public class BindingStepTest {
             String qualifiedName = prefix + kid.getName();
             if (kid.isDirectory()) {
                 grep(kid, text, qualifiedName + "/", matches);
-            } else if (kid.isFile() && FileUtils.readFileToString(kid, StandardCharsets.UTF_8).contains(text)) {
-                matches.add(qualifiedName);
+            } else {
+                try {
+                    if (FileUtils.readFileToString(kid, StandardCharsets.UTF_8).contains(text)) {
+                        matches.add(qualifiedName);
+                    }
+                } catch (FileNotFoundException | NoSuchFileException x) {
+                    // ignore, e.g. tmp file
+                }
             }
         }
     }


### PR DESCRIPTION
Otherwise can get PCT flakes such as

```
java.nio.file.NoSuchFileException: …/target/tmp/j h8642771068129316003/jobs/p/builds/1/atomic7832996773747571639.tmp
	at java.base/sun.nio.fs.UnixException.translateToIOException(UnixException.java:92)
	at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:111)
	at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:116)
	at java.base/sun.nio.fs.UnixFileSystemProvider.newByteChannel(UnixFileSystemProvider.java:219)
	at java.base/java.nio.file.Files.newByteChannel(Files.java:371)
	at java.base/java.nio.file.Files.newByteChannel(Files.java:422)
	at java.base/java.nio.file.spi.FileSystemProvider.newInputStream(FileSystemProvider.java:420)
	at java.base/java.nio.file.Files.newInputStream(Files.java:156)
	at org.apache.commons.io.FileUtils.lambda$readFileToString$12(FileUtils.java:2615)
	at org.apache.commons.io.IOUtils.toString(IOUtils.java:3239)
	at org.apache.commons.io.IOUtils.toString(IOUtils.java:3214)
	at org.apache.commons.io.FileUtils.readFileToString(FileUtils.java:2615)
	at org.jenkinsci.plugins.credentialsbinding.impl.BindingStepTest.grep(BindingStepTest.java:471)
	at org.jenkinsci.plugins.credentialsbinding.impl.BindingStepTest.grep(BindingStepTest.java:459)
	at org.jenkinsci.plugins.credentialsbinding.impl.BindingStepTest.lambda$cleanupAfterRestart$8(BindingStepTest.java:265)
```

when grepping the build directory before the build completes.
