### PR TITLE
Fix wrong masking of one-char-secrets in Jenkins output

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/credentialsbinding/masking/Base64SecretPatternFactory.java
+++ b/src/main/java/org/jenkinsci/plugins/credentialsbinding/masking/Base64SecretPatternFactory.java
@@ -38,8 +38,13 @@ public class Base64SecretPatternFactory implements SecretPatternFactory {
                 String shiftedSecret = shift + secret;
                 String encoded = encoder.encodeToString(shiftedSecret.getBytes(StandardCharsets.UTF_8));
                 String processedEncoded = shift.length() > 0 ? encoded.substring(2 * shift.length()) : encoded;
-                result.add(processedEncoded);
-                result.add(removeTrailingEquals(processedEncoded));
+                if (!processedEncoded.isEmpty()) {
+                    result.add(processedEncoded);
+                }
+                String processedWithoutTrailingEquals = removeTrailingEquals(processedEncoded);
+                if (!processedWithoutTrailingEquals.isEmpty()) {
+                    result.add(removeTrailingEquals(processedEncoded));
+                }
             }
         }
         return result;

--- a/src/test/java/org/jenkinsci/plugins/credentialsbinding/masking/Base64SecretPatternFactoryTest.java
+++ b/src/test/java/org/jenkinsci/plugins/credentialsbinding/masking/Base64SecretPatternFactoryTest.java
@@ -9,9 +9,13 @@ import org.jenkinsci.plugins.credentialsbinding.test.CredentialsTestUtil;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
+
+import java.util.Collection;
+import java.util.List;
 
 public class Base64SecretPatternFactoryTest {
 
@@ -51,5 +55,17 @@ public class Base64SecretPatternFactoryTest {
 
         j.assertLogContains("****", run);
         j.assertLogNotContains(SAMPLE_PASSWORD, run);
+    }
+
+    @Test
+    public void base64FormsAreNotEmpty() {
+        Base64SecretPatternFactory factory = new Base64SecretPatternFactory();
+        List<String> secrets = List.of("", "s", "s3", "s3cr3t");
+
+        secrets.forEach(secret -> {
+            Collection<String> base64Forms = factory.getBase64Forms(secret);
+            Assert.assertTrue("Failed for secret: '" + secret + "'. Method returned an empty string.",
+                    base64Forms.stream().noneMatch(String::isEmpty));
+        });
     }
 }


### PR DESCRIPTION
The fix makes sure that the Base64 secret patterns are not empty.

See https://issues.jenkins.io/browse/JENKINS-72412

### Testing done

The first of these commits include unit tests to demonstrate this issue.

```[tasklist]
### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
