### PR TITLE
Suppress warnings for spotbugs 4.8.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.76</version>
+    <version>4.77</version>
     <relativePath/>
   </parent>
 

--- a/src/main/java/org/jenkinsci/plugins/credentialsbinding/impl/SSHUserPrivateKeyBinding.java
+++ b/src/main/java/org/jenkinsci/plugins/credentialsbinding/impl/SSHUserPrivateKeyBinding.java
@@ -49,9 +49,9 @@ import java.util.Set;
 public class SSHUserPrivateKeyBinding extends MultiBinding<SSHUserPrivateKey> {
 
     public final String keyFileVariable;
-    @SuppressFBWarnings(value = "PA_PUBLIC_PRIMITIVE_ATTRIBUTE", justification = "Preserve API compatibility.")
+    @SuppressFBWarnings(value = "PA_PUBLIC_PRIMITIVE_ATTRIBUTE", justification = "TODO clean up")
     public String usernameVariable;
-    @SuppressFBWarnings(value = "PA_PUBLIC_PRIMITIVE_ATTRIBUTE", justification = "Preserve API compatibility.")
+    @SuppressFBWarnings(value = "PA_PUBLIC_PRIMITIVE_ATTRIBUTE", justification = "TODO clean up")
     public String passphraseVariable;
 
     @DataBoundConstructor public SSHUserPrivateKeyBinding(@NonNull String keyFileVariable, String credentialsId) {

--- a/src/main/java/org/jenkinsci/plugins/credentialsbinding/impl/SSHUserPrivateKeyBinding.java
+++ b/src/main/java/org/jenkinsci/plugins/credentialsbinding/impl/SSHUserPrivateKeyBinding.java
@@ -26,6 +26,7 @@ import com.cloudbees.jenkins.plugins.sshcredentials.SSHUserPrivateKey;
 import com.google.common.collect.ImmutableSet;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
 import hudson.FilePath;
 import hudson.Launcher;
@@ -48,7 +49,9 @@ import java.util.Set;
 public class SSHUserPrivateKeyBinding extends MultiBinding<SSHUserPrivateKey> {
 
     public final String keyFileVariable;
+    @SuppressFBWarnings(value = "PA_PUBLIC_PRIMITIVE_ATTRIBUTE", justification = "Preserve API compatibility.")
     public String usernameVariable;
+    @SuppressFBWarnings(value = "PA_PUBLIC_PRIMITIVE_ATTRIBUTE", justification = "Preserve API compatibility.")
     public String passphraseVariable;
 
     @DataBoundConstructor public SSHUserPrivateKeyBinding(@NonNull String keyFileVariable, String credentialsId) {


### PR DESCRIPTION
## Suppress warnings for spotbugs 4.8.3

[Plugin pom 4.77](https://github.com/jenkinsci/plugin-pom/releases/tag/plugin-4.77) needs this change to resolve new spotbugs warnings that will be reported by spotbugs 4.8.3 and later.

Can skip the changelog, since this is not visible to users.

### Testing done

Confirmed that the spotbugs warnings are visible when using the 4.77-SNAPSHOT plugin pom before this change. With this change, the spotbugs warnings are no longer visible.

Confirmed that spotbugs is silent with plugin pom 4.77 after this change.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
```
