### PR TITLE
[JENKINS-72412] Overmasking when trivial “secrets” bound

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/credentialsbinding/masking/Base64SecretPatternFactory.java
+++ b/src/main/java/org/jenkinsci/plugins/credentialsbinding/masking/Base64SecretPatternFactory.java
@@ -38,13 +38,8 @@ public class Base64SecretPatternFactory implements SecretPatternFactory {
                 String shiftedSecret = shift + secret;
                 String encoded = encoder.encodeToString(shiftedSecret.getBytes(StandardCharsets.UTF_8));
                 String processedEncoded = shift.length() > 0 ? encoded.substring(2 * shift.length()) : encoded;
-                if (!processedEncoded.isEmpty()) {
-                    result.add(processedEncoded);
-                }
-                String processedWithoutTrailingEquals = removeTrailingEquals(processedEncoded);
-                if (!processedWithoutTrailingEquals.isEmpty()) {
-                    result.add(removeTrailingEquals(processedEncoded));
-                }
+                result.add(processedEncoded);
+                result.add(removeTrailingEquals(processedEncoded));
             }
         }
         return result;

--- a/src/main/java/org/jenkinsci/plugins/credentialsbinding/masking/SecretPatterns.java
+++ b/src/main/java/org/jenkinsci/plugins/credentialsbinding/masking/SecretPatterns.java
@@ -45,6 +45,12 @@ public class SecretPatterns {
             Comparator.comparingInt(String::length).reversed().thenComparing(String::compareTo);
 
     /**
+     * Masking (encoded) “secrets” shorter than this would just be ridiculous.
+     * Particularly relevant with {@link Base64SecretPatternFactory}.
+     */
+    private static final int MINIMUM_ENCODED_LENGTH = 3;
+
+    /**
      * Constructs a regular expression to match against all known forms that the given collection of input strings may
      * appear. This pattern is optimized such that longer masks are checked before shorter masks. By doing so, this
      * makes inputs that are substrings of other inputs be masked as the longer input, though there is no guarantee
@@ -61,6 +67,7 @@ public class SecretPatterns {
                 .flatMap(input ->
                         secretPatternFactories.stream().flatMap(factory ->
                                 factory.getEncodedForms(input).stream()))
+                .filter(encoded -> encoded.length() >= MINIMUM_ENCODED_LENGTH)
                 .sorted(BY_LENGTH_DESCENDING)
                 .distinct()
                 .map(Pattern::quote)

--- a/src/test/java/org/jenkinsci/plugins/credentialsbinding/masking/Base64SecretPatternFactoryTest.java
+++ b/src/test/java/org/jenkinsci/plugins/credentialsbinding/masking/Base64SecretPatternFactoryTest.java
@@ -9,13 +9,9 @@ import org.jenkinsci.plugins.credentialsbinding.test.CredentialsTestUtil;
 import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
 import org.jenkinsci.plugins.workflow.job.WorkflowRun;
-import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
-
-import java.util.Collection;
-import java.util.List;
 
 public class Base64SecretPatternFactoryTest {
 
@@ -55,17 +51,5 @@ public class Base64SecretPatternFactoryTest {
 
         j.assertLogContains("****", run);
         j.assertLogNotContains(SAMPLE_PASSWORD, run);
-    }
-
-    @Test
-    public void base64FormsAreNotEmpty() {
-        Base64SecretPatternFactory factory = new Base64SecretPatternFactory();
-        List<String> secrets = List.of("", "s", "s3", "s3cr3t");
-
-        secrets.forEach(secret -> {
-            Collection<String> base64Forms = factory.getBase64Forms(secret);
-            Assert.assertTrue("Failed for secret: '" + secret + "'. Method returned an empty string.",
-                    base64Forms.stream().noneMatch(String::isEmpty));
-        });
     }
 }


### PR DESCRIPTION
Amends #269. Keeps the integration test from #284 but reimplements the fix; I found that even input secrets of several characters could produce junk sequences in `Base64SecretPatternFactory`.