### PR TITLE
[JENKINS-75914] Do not mask text less than 2 characters

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/credentialsbinding/impl/MaskedException.java
+++ b/src/main/java/org/jenkinsci/plugins/credentialsbinding/impl/MaskedException.java
@@ -12,6 +12,9 @@ final class MaskedException extends Exception {
     private static final long serialVersionUID = 1L;
 
     static Throwable of(@NonNull Throwable unmasked, Pattern pattern) {
+        if (pattern.toString().length() < 3) {
+            return unmasked;
+        }
         return of(unmasked, new HashSet<>(), pattern);
     }
 

--- a/src/test/java/org/jenkinsci/plugins/credentialsbinding/impl/MaskedExceptionTest.java
+++ b/src/test/java/org/jenkinsci/plugins/credentialsbinding/impl/MaskedExceptionTest.java
@@ -1,0 +1,67 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2025 CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.jenkinsci.plugins.credentialsbinding.impl;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+
+import java.util.regex.Pattern;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
+
+public class MaskedExceptionTest {
+    @Issue("JENKINS-75914")
+    @Test
+    public void maskedExceptionIgnoresShortSecretsEmpty() throws Exception {
+        Exception unmasked = new Exception("An empty pattern for exception mask");
+        var masked = MaskedException.of(unmasked, Pattern.compile(""));
+        assertThat(masked.getMessage(), not(containsString("****")));
+    }
+
+    @Issue("JENKINS-75914")
+    @Test
+    public void maskedExceptionIgnoresShortSecrets1Char() throws Exception {
+        Exception unmasked = new Exception("1 character pattern for exception mask");
+        var masked = MaskedException.of(unmasked, Pattern.compile("e"));
+        assertThat(masked.getMessage(), not(containsString("****")));
+    }
+
+    @Issue("JENKINS-75914")
+    @Test
+    public void maskedExceptionIgnoresShortSecrets2Char() throws Exception {
+        Exception unmasked = new Exception("2 character pattern for exception mask");
+        var masked = MaskedException.of(unmasked, Pattern.compile("n "));
+        assertThat(masked.getMessage(), not(containsString("****")));
+    }
+
+    @Issue("JENKINS-75914")
+    @Test
+    public void maskedExceptionIgnoresShortSecrets4Char() throws Exception {
+        Exception unmasked = new Exception("4 character pattern for exception mask");
+        var masked = MaskedException.of(unmasked, Pattern.compile("patt"));
+        assertThat(masked.getMessage(), containsString("****"));
+    }
+}


### PR DESCRIPTION
## [JENKINS-75914] Do not mask text less than 2 characters

The bug submitter was using a zero length secret text and it significantly increased the log output.  Require that the matched regular expression pattern must contain at least two characters.

### Testing done

* Wrote automated tests to confirm original exception is returned when string is less than 3 characters
* Ran the revised plugin in Jenkins and confirmed that the excess asterisks are not displayed

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
