### PR TITLE
[JENKINS-75914] Do not mask empty secrets

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/credentialsbinding/impl/BindingStep.java
+++ b/src/main/java/org/jenkinsci/plugins/credentialsbinding/impl/BindingStep.java
@@ -163,6 +163,9 @@ public final class BindingStep extends Step {
             @NonNull
             @Override
             public Throwable handle(@NonNull StepContext ctx, @NonNull Throwable t) {
+                if (Secret.toString(secretPattern).isEmpty()) {
+                    return t;
+                }
                 return MaskedException.of(t, Pattern.compile(secretPattern.getPlainText()));
             }
         }


### PR DESCRIPTION
## [JENKINS-75914] Do not mask empty secrets
<!-- Please describe your pull request here. -->
Supersedes https://github.com/jenkinsci/credentials-binding-plugin/pull/377.

The issue encountered in [JENKINS-75914](https://issues.jenkins.io/browse/JENKINS-75914) is due to the lack of handling for empty credentials. 
A check is performed for normal messages on the console log https://github.com/jenkinsci/credentials-binding-plugin/blob/baac667811a5f0121077979911c5853a8fb1ab12/src/main/java/org/jenkinsci/plugins/credentialsbinding/masking/SecretPatterns.java#L102, but not for exceptions.

I'm adding this check before changing the type of exception, to avoid throwing a `MaskedException` when there's nothing to mask.

### Testing done

I tested this change locally using the example provided in [JENKINS-75914](https://issues.jenkins.io/browse/JENKINS-75914) and added a test to cover this case. The test fails without this change.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [X] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
