### PR TITLE
Remove redundant test assertions incompatible with latest credentials plugin

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/credentialsbinding/impl/UsernamePasswordBindingTest.java
+++ b/src/test/java/org/jenkinsci/plugins/credentialsbinding/impl/UsernamePasswordBindingTest.java
@@ -121,7 +121,6 @@ class UsernamePasswordBindingTest {
 
         JenkinsRule.WebClient wc = r.createWebClient();
         HtmlPage page = wc.goTo("credentials/store/system/domain/_/credentials/secret-id");
-        assertThat("Have usage tracking reported", page.getElementById("usage"), notNullValue());
         assertThat("No fingerprint created until first use", page.getElementById("usage-missing"), notNullValue());
         assertThat("No fingerprint created until first use", page.getElementById("usage-present"), nullValue());
 
@@ -143,7 +142,6 @@ class UsernamePasswordBindingTest {
         assertThat("A job that does nothing does not use parameterized credentials", fingerprint, nullValue());
 
         page = wc.goTo("credentials/store/system/domain/_/credentials/secret-id");
-        assertThat("Have usage tracking reported", page.getElementById("usage"), notNullValue());
         assertThat("No fingerprint created until first use", page.getElementById("usage-missing"), notNullValue());
         assertThat("No fingerprint created until first use", page.getElementById("usage-present"), nullValue());
 


### PR DESCRIPTION
## Remove redundant test assertions incompatible with latest credentials plugin

Existing assertions already check that the credential usage tracking is correct.  The deleted assertions add no real value to the tests and are incompatible with the most recent releases of the credentials plugin.

Previously there was an `h2` header with an `id="h2"`.  That has been removed while still retaining the rest of the usages data on the page.

Detected in plugin BOM pull request:

* https://github.com/jenkinsci/bom/pull/6516

### Testing done

* Confirmed that tests pass with older credentials plugin and with latest credentials plugin.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
