### PR TITLE
Skip credentials cleanup when the agent is offline

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/credentialsbinding/impl/BindingStep.java
+++ b/src/main/java/org/jenkinsci/plugins/credentialsbinding/impl/BindingStep.java
@@ -34,6 +34,7 @@ import hudson.model.AbstractBuild;
 import hudson.model.Run;
 import hudson.model.TaskListener;
 import hudson.util.Secret;
+import java.io.IOException;
 import java.io.ObjectStreamException;
 import java.io.OutputStream;
 import java.io.Serializable;
@@ -263,11 +264,27 @@ public final class BindingStep extends Step {
         }
 
         @Override protected void finished(StepContext context) throws Exception {
+            final FilePath workspace;
+            final Launcher launcher;
+            try {
+                workspace = context.get(FilePath.class);
+                launcher = context.get(Launcher.class);
+            } catch (IOException x) {
+                // The agent that hosted the workspace is no longer online (e.g. AgentOfflineException:
+                // the build agent's pod/node was deleted or lost). The temporary credential files lived
+                // in that workspace and are gone with it, so there is nothing to unbind. Skipping cleanup
+                // here avoids turning a recoverable agent loss into a build failure (and, under retry,
+                // avoids this late cleanup becoming the terminal build result).
+                context.get(TaskListener.class).getLogger().println(
+                        "Skipping credentials cleanup because the agent is no longer online: " + x.getMessage());
+                return;
+            }
+
             Exception xx = null;
 
             for (MultiBinding.Unbinder unbinder : unbinders) {
                 try {
-                    unbinder.unbind(context.get(Run.class), context.get(FilePath.class), context.get(Launcher.class), context.get(TaskListener.class));
+                    unbinder.unbind(context.get(Run.class), workspace, launcher, context.get(TaskListener.class));
                 } catch (Exception x) {
                     if (xx == null) {
                         xx = x;

--- a/src/test/java/org/jenkinsci/plugins/credentialsbinding/impl/BindingStepTest.java
+++ b/src/test/java/org/jenkinsci/plugins/credentialsbinding/impl/BindingStepTest.java
@@ -312,6 +312,33 @@ class BindingStepTest {
         });
     }
 
+    @Test
+    void cleanupSkippedWhenAgentGoesOffline() throws Throwable {
+        final String secret = "s3cr3t";
+        extension.then(r -> {
+            FileCredentialsImpl c = new FileCredentialsImpl(CredentialsScope.GLOBAL, "creds", "sample", "secret.txt", SecretBytes.fromBytes(secret.getBytes()));
+            CredentialsProvider.lookupStores(r.jenkins).iterator().next().addCredentials(Domain.global(), c);
+            r.createSlave("myslave", null, null);
+            WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
+            p.setDefinition(new CpsFlowDefinition("""
+                    node('myslave') {
+                      withCredentials([file(variable: 'SECRET', credentialsId: 'creds')]) {
+                        semaphore 'wait'
+                      }
+                    }""", true));
+            WorkflowRun b = p.scheduleBuild2(0).waitForStart();
+            SemaphoreStep.waitForStart("wait/1", b);
+            // Simulate the agent's pod/node being lost mid-body (e.g. a Kubernetes pod deleted or a
+            // node preemption): the workspace FilePath can no longer be resolved, so the
+            // withCredentials cleanup would otherwise raise AgentOfflineException.
+            r.jenkins.removeNode(Objects.requireNonNull(r.jenkins.getNode("myslave")));
+            r.waitForCompletion(b);
+            // The cleanup must detect the offline agent and skip, rather than throwing (which would
+            // compound the agent-loss failure and, under retry, could become the terminal result).
+            r.assertLogContains("Skipping credentials cleanup because the agent is no longer online", b);
+        });
+    }
+
     @Issue("JENKINS-27389")
     @Test
     void grabEnv() throws Throwable {


### PR DESCRIPTION
Fixes #531

### Problem

When an agent is lost while a `withCredentials` block is active (e.g. a Kubernetes pod is
deleted or a node is preempted), the deferred cleanup callback `BindingStep$Callback.finished`
resolves the agent workspace via `context.get(FilePath.class)`. Since the agent/channel is gone,
that throws `AgentOfflineException`, which the callback collects and re-throws.

Consequences:

- A *recoverable* agent loss is turned into a hard error.
- Under `retry` / declarative `agent { … retries N }`, this cleanup can fire late (after the
  "wait for the agent to come back" window) and surface as the **terminal build result**,
  defeating the retry — the build fails referencing the already-dead agent.

The cleanup only deletes the temporary secret files from the workspace
(`UnbindableDir.UnbinderImpl.unbind` → `deleteRecursive()`), which is impossible and pointless
once the workspace/agent is gone.

### Change

In `Callback.finished`, resolve `FilePath`/`Launcher` up front; if that fails with `IOException`
(the agent is offline/removed), log a line and return without throwing. Genuine unbind failures
(agent reachable) are still collected and thrown as before. Behavior for workspace-less bindings
is unchanged (`get(FilePath)` returns `null` rather than throwing).

Note: `AgentOfflineException` is package-private in `workflow-durable-task-step`, so it is caught
via its `IOException` supertype. If preferred, a follow-up could make that type public and catch
it specifically.

### Testing

- New `BindingStepTest#cleanupSkippedWhenAgentGoesOffline`: runs a `withCredentials` file binding
  on an agent, removes the node mid-body, and asserts the build logs
  `Skipping credentials cleanup because the agent is no longer online` instead of failing via the
  cleanup callback.
- Existing `BindingStepTest` suite still passes (19/19).
- Built and tested with Maven 3.9 / Java 21 against baseline Jenkins 2.479.3.
