### PR TITLE
Restrict file location for SSH and certificates credentials

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/credentialsbinding/impl/CertificateMultiBinding.java
+++ b/src/main/java/org/jenkinsci/plugins/credentialsbinding/impl/CertificateMultiBinding.java
@@ -1,5 +1,6 @@
 package org.jenkinsci.plugins.credentialsbinding.impl;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.security.KeyStoreException;
@@ -84,7 +85,8 @@ public class CertificateMultiBinding extends MultiBinding<StandardCertificateCre
 
 		if (workspace != null) {
 			final UnbindableDir secrets = UnbindableDir.create(workspace);
-			final FilePath secret = secrets.getDirPath().child("keystore-" + keystoreVariable);
+			String safeKeystoreVariable = new FilePath(new File(keystoreVariable)).getName();
+			final FilePath secret = secrets.getDirPath().child("keystore-" + safeKeystoreVariable);
 			OutputStream out = secret.write();
 			try {
 				credentials.getKeyStore().store(out, storePassword.toCharArray());

--- a/src/main/java/org/jenkinsci/plugins/credentialsbinding/impl/SSHUserPrivateKeyBinding.java
+++ b/src/main/java/org/jenkinsci/plugins/credentialsbinding/impl/SSHUserPrivateKeyBinding.java
@@ -40,6 +40,7 @@ import org.jenkinsci.plugins.credentialsbinding.MultiBinding;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -102,7 +103,8 @@ public class SSHUserPrivateKeyBinding extends MultiBinding<SSHUserPrivateKey> {
                                            @NonNull TaskListener listener) throws IOException, InterruptedException {
         SSHUserPrivateKey sshKey = getCredentials(build);
         UnbindableDir keyDir = UnbindableDir.create(workspace);
-        FilePath keyFile =  keyDir.getDirPath().child("ssh-key-" + keyFileVariable);
+        String safeKeyFileVariable = new FilePath(new File(keyFileVariable)).getName();
+        FilePath keyFile =  keyDir.getDirPath().child("ssh-key-" + safeKeyFileVariable);
 
         StringBuilder contents = new StringBuilder();
         for (String key : sshKey.getPrivateKeys()) {

--- a/src/test/java/org/jenkinsci/plugins/credentialsbinding/impl/CertificateMultiBindingTest.java
+++ b/src/test/java/org/jenkinsci/plugins/credentialsbinding/impl/CertificateMultiBindingTest.java
@@ -30,6 +30,7 @@ import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.File;
@@ -197,4 +198,29 @@ class CertificateMultiBindingTest {
         return result;
     }
 
+    @Test
+    void keystoreVariablePathTraversal() throws Exception {
+        String payload = "../../../../p0wn3d-keystore";
+		String alias = "androiddebugkey";
+		String password = "android";
+		StandardCertificateCredentials c = new CertificateCredentialsImpl(CredentialsScope.GLOBAL, null, alias,
+				password, new CertificateCredentialsImpl.UploadedKeyStoreSource(new FileParameterValue.FileItemImpl(certificate), null));
+		CredentialsProvider.lookupStores(r.jenkins).iterator().next().addCredentials(Domain.global(), c);
+
+		WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "p");
+		p.setDefinition(new CpsFlowDefinition(
+				"node {\n" +
+						"  withCredentials([certificate(credentialsId: '" + c.getId() + "', keystoreVariable: '" + payload + "')]) {\n" +
+						"    echo 'bound'\n" +
+						"  }\n" +
+						"}", true));
+
+		r.buildAndAssertSuccess(p);
+
+		FilePath workspace = r.jenkins.getWorkspaceFor(p);
+		FilePath secretsDir = UnbindableDir.create(workspace).getDirPath();
+		FilePath resolvedPath = secretsDir.child("keystore-" + payload);
+
+		assertFalse(resolvedPath.exists(), "Keystore file should not exist outside secure directory");
+    }
 }

--- a/src/test/java/org/jenkinsci/plugins/credentialsbinding/impl/SSHUserPrivateKeyBindingTest.java
+++ b/src/test/java/org/jenkinsci/plugins/credentialsbinding/impl/SSHUserPrivateKeyBindingTest.java
@@ -50,6 +50,7 @@ import org.jvnet.hudson.test.junit.jupiter.BuildWatcherExtension;
 import org.jvnet.hudson.test.junit.jupiter.JenkinsSessionExtension;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -255,5 +256,31 @@ class SSHUserPrivateKeyBindingTest {
                 assertEquals(keyContent, key.readToString().trim());
             }
         );
+    }
+
+    @Test
+    void keyFileVariablePathTraversal() throws Throwable {
+        String payload = "../../../../p0wn3d-ssh.key";
+
+        extension.then(j -> {
+            SSHUserPrivateKey c = new DummyPrivateKey("sshCred", "bob", "secret", "the-key");
+            CredentialsProvider.lookupStores(j.jenkins).iterator().next().addCredentials(Domain.global(), c);
+
+            WorkflowJob p = j.jenkins.createProject(WorkflowJob.class, "p");
+            p.setDefinition(new CpsFlowDefinition(
+                    "node {\n" +
+                            "  withCredentials([sshUserPrivateKey(credentialsId: 'sshCred', keyFileVariable: '" + payload + "')]) {\n" +
+                            "    echo 'bound'\n" +
+                            "  }\n" +
+                            "}", true));
+
+            WorkflowRun run = j.buildAndAssertSuccess(p);
+
+            FilePath workspace = j.jenkins.getWorkspaceFor(p);
+            FilePath keyDir = UnbindableDir.create(workspace).getDirPath();
+            FilePath resolvedPath = keyDir.child("ssh-key-" + payload);
+
+            assertFalse(resolvedPath.exists(), "SSH key file should not exist outside secure directory");
+        });
     }
 }


### PR DESCRIPTION
https://github.com/jenkinsci/credentials-binding-plugin/issues/532

<!-- Please describe your pull request here. -->

### Testing done

Confirmed locally the file is not created outside the expected directory with the following pipeline
```
node {
  withCredentials([sshUserPrivateKey(credentialsId:'demo-ssh-key',
    keyFileVariable:'../../../../myFile')]) { }
}
```
did the same for certificate creds.


<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
